### PR TITLE
fix:  on fees cancel ignore Payment Ledger Entry

### DIFF
--- a/education/education/doctype/fees/fees.py
+++ b/education/education/doctype/fees/fees.py
@@ -93,7 +93,7 @@ class Fees(AccountsController):
 			)
 
 	def on_cancel(self):
-		self.ignore_linked_doctypes = ("GL Entry", "Stock Ledger Entry")
+		self.ignore_linked_doctypes = ("GL Entry", "Payment Ledger Entry")
 		make_reverse_gl_entries(voucher_type=self.doctype, voucher_no=self.name)
 		# frappe.db.set(self, 'status', 'Cancelled')
 


### PR DESCRIPTION
critical fix . 
Issue : user is unable to cancel Fees. 
This PR fixes it.

Note : Stock Ledger Entry has nothing to do with Fees hence removed.

@ruchamahabal  @rohitwaghchaure  @deepeshgarg007 . Please review, it is URGENT & critical.
