### PR TITLE
fix: load only students in guardian child table

### DIFF
--- a/education/education/doctype/guardian/guardian.py
+++ b/education/education/doctype/guardian/guardian.py
@@ -20,7 +20,7 @@ class Guardian(Document):
 		"""Load `students` from the database"""
 		self.students = []
 		students = frappe.get_all(
-			"Student Guardian", filters={"guardian": self.name}, fields=["parent"]
+			"Student Guardian", filters={"guardian": self.name, "parenttype":"Student"}, fields=["parent"]
 		)
 		for student in students:
 			self.append(


### PR DESCRIPTION
Filter by parenttype Student while fetching students linked to a guardian .
This will exclude records linked to other doctypes like Student Applicant 