### PR TITLE
fix: error when viewing guardian

### DIFF
--- a/education/education/doctype/guardian/guardian.py
+++ b/education/education/doctype/guardian/guardian.py
@@ -27,7 +27,7 @@ class Guardian(Document):
 				"students",
 				{
 					"student": student.parent,
-					"student_name": frappe.db.get_value("Student", student.parent, "title"),
+					"student_name": frappe.db.get_value("Student", student.parent, "student_name"),
 				},
 			)
 


### PR DESCRIPTION
This fix error when viewing Guardian attached to Student.

https://github.com/frappe/education/issues/119