### PR TITLE
Solves Error

### DIFF
--- a/education/education/doctype/guardian/guardian.py
+++ b/education/education/doctype/guardian/guardian.py
@@ -27,7 +27,7 @@ class Guardian(Document):
 				"students",
 				{
 					"student": student.parent,
-					"student_name": frappe.db.get_value("Student", student.parent, "title"),
+					"student_name": frappe.db.get_value("Student", student.parent, "student_name"),
 				},
 			)
 


### PR DESCRIPTION
When opening doctype "Guardian" that has "Students" connected to it. "Guardian" can not be opened because is trying to fetch the field "title" from doctype "Student", which does not exist.
![image](https://user-images.githubusercontent.com/11473213/236662398-652b3926-3b83-42fb-be5a-4278dc2d1c3e.png)

