### PR TITLE
Disable Assessment Result Tool Input field while saving result

### DIFF
--- a/education/education/doctype/assessment_result_tool/assessment_result_tool.js
+++ b/education/education/doctype/assessment_result_tool/assessment_result_tool.js
@@ -107,6 +107,11 @@ frappe.ui.form.on('Assessment Result Tool', {
 					.each(function(el, input){
 					student_scores["comment"] = $(input).val();
 				});
+
+				// Disable the input box and result mark for the result
+				result_table.find(`input[data-student='${student}'].student-result-data`).attr('disabled', true);
+				$(link_span).css("display", "none");
+				
 				frappe.call({
 					method: "education.education.api.mark_assessment_result",
 					args: {
@@ -129,6 +134,9 @@ frappe.ui.form.on('Assessment Result Tool', {
 						let link_span = result_table.find(`span[data-student=${assessment_result.student}].total-result-link`);
 						$(link_span).css("display", "block");
 						$(link_span).find("a").attr("href", "/app/assessment-result/"+assessment_result.name);
+
+						// Enable the input box for the result
+						result_table.find(`input[data-student='${student}'].student-result-data`).attr('disabled', false);
 					}
 				});
 			}


### PR DESCRIPTION
Disable the input field when the result is saving. This is to prevent assessment result duplication, especially when the network is poor

https://github.com/frappe/education/assets/63661278/77c9efe2-a079-4f6a-9e6e-3dcef1731c35

