### PR TITLE
fix: Error while creating student if email address is not mandatory.

### DIFF
--- a/education/education/doctype/student/student.json
+++ b/education/education/doctype/student/student.json
@@ -107,6 +107,7 @@
    "fieldtype": "Data",
    "in_global_search": 1,
    "label": "Student Email Address",
+   "reqd": 1,
    "unique": 1
   },
   {
@@ -282,7 +283,7 @@
  ],
  "image_field": "image",
  "links": [],
- "modified": "2023-02-06 12:25:25.197460",
+ "modified": "2023-09-01 17:28:07.028913",
  "modified_by": "Administrator",
  "module": "Education",
  "name": "Student",


### PR DESCRIPTION
email should be made mandatory, coz if we don't put any email while creating student we get the following error :
<img width="1467" alt="image" src="https://github.com/frappe/education/assets/65544983/2e8068fb-ffd8-44bb-9627-ea9526d34c5f">
