### PR TITLE
fix: start_date and end_date should be mandatory in Academic Year Doctype

### DIFF
--- a/education/education/doctype/academic_year/academic_year.json
+++ b/education/education/doctype/academic_year/academic_year.json
@@ -24,14 +24,16 @@
    "fieldname": "year_start_date",
    "fieldtype": "Date",
    "in_list_view": 1,
-   "label": "Year Start Date"
+   "label": "Year Start Date",
+   "reqd": 1
   },
   {
    "allow_in_quick_entry": 1,
    "fieldname": "year_end_date",
    "fieldtype": "Date",
    "in_list_view": 1,
-   "label": "Year End Date"
+   "label": "Year End Date",
+   "reqd": 1
   },
   {
    "fieldname": "connections_tab",
@@ -41,7 +43,7 @@
   }
  ],
  "links": [],
- "modified": "2023-02-13 17:50:21.149012",
+ "modified": "2023-10-30 16:34:17.354467",
  "modified_by": "Administrator",
  "module": "Education",
  "name": "Academic Year",


### PR DESCRIPTION
**Issue:**

When creating a course_schedule we get the following error ⬇️
![2023-10-30 16 36 49](https://github.com/frappe/education/assets/65544983/60d0da11-96ec-4c6f-a476-72a6968ab369)


**Reason:**

_start_date_ and _end_date_ are not mandatory in "Academic Year Doctype"
where as these are mandatory in "Academic term Doctype".

**Solution:**
_start_date_ and _end_date_ should be mandatory.

