### PR TITLE
fix: option to enroll a student if the student is rejected by mistake

### DIFF
--- a/education/education/doctype/student_applicant/student_applicant.js
+++ b/education/education/doctype/student_applicant/student_applicant.js
@@ -36,6 +36,13 @@ frappe.ui.form.on("Student Applicant", {
 			}, 'Actions');
 		}
 
+		if (!frm.is_new() && frm.doc.application_status === "Rejected") {
+			frm.add_custom_button(__("Enroll"), function() {
+				frm.set_value("application_status", "Applied");
+				frm.save_or_update();
+			}, 'Actions');
+		}
+
 		frappe.realtime.on("enroll_student_progress", function(data) {
 			if(data.progress) {
 				frappe.hide_msgprint(true);

--- a/education/education/doctype/student_applicant/student_applicant.js
+++ b/education/education/doctype/student_applicant/student_applicant.js
@@ -37,8 +37,8 @@ frappe.ui.form.on("Student Applicant", {
 		}
 
 		if (!frm.is_new() && frm.doc.application_status === "Rejected") {
-			frm.add_custom_button(__("Enroll"), function() {
-				frm.set_value("application_status", "Applied");
+			frm.add_custom_button(__("Approve"), function() {
+				frm.set_value("application_status", "Approved");
 				frm.save_or_update();
 			}, 'Actions');
 		}


### PR DESCRIPTION
Currently when we reject a student by mistake or when we reject a student and wants to re-enroll them later, then there is no option to Enroll the student back again.

So we should have an option to Re-Enroll them.

P.S =>
This might not be the right fix (maybe only Admin can do it), raising this PR so that I can update it later if there is a better way to do the same.

