### PR TITLE
fix: program enrollment tool enroll students bug

### DIFF
--- a/education/education/doctype/program_enrollment_tool/program_enrollment_tool.js
+++ b/education/education/doctype/program_enrollment_tool/program_enrollment_tool.js
@@ -17,6 +17,12 @@ frappe.ui.form.on("Program Enrollment Tool", {
 			frappe.hide_msgprint(true);
 			frappe.show_progress(__("Enrolling students"), data.progress[0], data.progress[1]);
 		});
+
+		frm.add_fetch(
+			frm.doc.academic_term ? "new_academic_term" : "new_academic_year",
+			frm.doc.academic_term ? "term_start_date" : "year_start_date",
+			"enrollment_date"
+		);
 	},
 
 	get_students_from: function(frm) {
@@ -47,5 +53,9 @@ frappe.ui.form.on("Program Enrollment Tool", {
 				frappe.hide_msgprint(true);
 			}
 		});
+	},
+
+	"academic_term": function(frm) {
+		frm.refresh();
 	}
 });

--- a/education/education/doctype/program_enrollment_tool/program_enrollment_tool.json
+++ b/education/education/doctype/program_enrollment_tool/program_enrollment_tool.json
@@ -90,12 +90,14 @@
    "fieldname": "new_program",
    "fieldtype": "Link",
    "label": "New Program",
+   "mandatory_depends_on": "eval:doc.get_students_from==\"Program Enrollment\"",
    "options": "Program"
   },
   {
    "fieldname": "new_student_batch",
    "fieldtype": "Link",
    "label": "New Student Batch",
+   "mandatory_depends_on": "eval:doc.student_batch",
    "options": "Student Batch Name"
   },
   {
@@ -133,7 +135,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-16 01:49:23.391107",
+ "modified": "2023-11-16 14:35:38.467928",
  "modified_by": "Administrator",
  "module": "Education",
  "name": "Program Enrollment Tool",

--- a/education/education/doctype/program_enrollment_tool/program_enrollment_tool.json
+++ b/education/education/doctype/program_enrollment_tool/program_enrollment_tool.json
@@ -11,6 +11,7 @@
   "column_break_3",
   "academic_year",
   "academic_term",
+  "enrollment_date",
   "section_break_5",
   "get_students",
   "students",
@@ -119,13 +120,20 @@
    "fieldname": "new_academic_term",
    "fieldtype": "Link",
    "label": "New Academic Term",
+   "mandatory_depends_on": "eval:doc.academic_term",
    "options": "Academic Term"
+  },
+  {
+   "depends_on": "eval:doc.get_students_from==\"Program Enrollment\"",
+   "fieldname": "enrollment_date",
+   "fieldtype": "Date",
+   "label": "Enrollment Date"
   }
  ],
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-09 14:11:27.028036",
+ "modified": "2023-11-16 01:49:23.391107",
  "modified_by": "Administrator",
  "module": "Education",
  "name": "Program Enrollment Tool",

--- a/education/education/doctype/program_enrollment_tool/program_enrollment_tool.py
+++ b/education/education/doctype/program_enrollment_tool/program_enrollment_tool.py
@@ -87,6 +87,7 @@ class ProgramEnrollmentTool(Document):
 				prog_enrollment.student_batch_name = (
 					stud.student_batch_name if stud.student_batch_name else self.new_student_batch
 				)
+				prog_enrollment.enrollment_date = self.enrollment_date
 				prog_enrollment.save()
 			elif stud.student_applicant:
 				prog_enrollment = enroll_student(stud.student_applicant)


### PR DESCRIPTION
Currently when we try to enroll students from one term to new term or from current year to next year.
We get the following error:
<img width="1281" alt="Screenshot 2023-11-16 at 1 05 19 AM" src="https://github.com/frappe/education/assets/65544983/67182764-87be-4127-a620-f1840432b1d8">

**Reason:**
_enrollment_data_ in the "Program Enrollment" Doctype by default is set to "Today" which results in the above error.

**Fix:**
Add a field called _enrollment_date_ in "Program Enrollment Tool"  and while creating Program Enrollment use the _enrollment_date_ from the Tool
 
