### PR TITLE
fix: change type of Year from select to Link in Student Monthly Attendance Report

### DIFF
--- a/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.js
+++ b/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.js
@@ -15,7 +15,8 @@ frappe.query_reports["Student Monthly Attendance Sheet"] = {
 	{
 		"fieldname": "year",
 		"label": __("Year"),
-		"fieldtype": "Select",
+		"fieldtype": "Link",
+		"options":"Academic Year",
 		"reqd": 1
 	},
 	{
@@ -26,17 +27,4 @@ frappe.query_reports["Student Monthly Attendance Sheet"] = {
 		"reqd": 1
 	}
 	],
-
-	"onload": function() {
-		return frappe.call({
-			method: "education.education.report.student_monthly_attendance_sheet.student_monthly_attendance_sheet.get_attendance_years",
-			callback: function(r) {
-				var year_filter = frappe.query_report.get_filter('year');
-				year_filter.df.options = r.message;
-				year_filter.df.default = r.message.split("\n")[0];
-				year_filter.refresh();
-				year_filter.set_input(year_filter.df.default);
-			}
-		});
-	}
 }

--- a/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
+++ b/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
@@ -149,16 +149,6 @@ def daterange(d1, d2):
 	return (d1 + datetime.timedelta(days=i) for i in range((d2 - d1).days + 1))
 
 
-@frappe.whitelist()
-def get_attendance_years():
-	year_list = frappe.db.sql_list(
-		"""select distinct YEAR(date) from `tabStudent Attendance` ORDER BY YEAR(date) DESC"""
-	)
-	if not year_list:
-		year_list = [getdate().year]
-	return "\n".join(str(year) for year in year_list)
-
-
 def mark_holidays(att_map, from_date, to_date, students_list):
 	holiday_list = get_holiday_list()
 	holidays = get_holidays(holiday_list)

--- a/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
+++ b/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
@@ -5,20 +5,27 @@
 import frappe
 from erpnext.support.doctype.issue.issue import get_holidays
 from frappe import _
-from frappe.utils import (add_days, cstr, date_diff, get_first_day,
-                          get_last_day, getdate)
+from frappe.utils import add_days, cstr, date_diff, get_first_day, get_last_day, getdate
 
 from education.education.api import get_student_group_students
-from education.education.doctype.student_attendance.student_attendance import \
-    get_holiday_list
+from education.education.doctype.student_attendance.student_attendance import (
+	get_holiday_list,
+)
 
 
 def execute(filters=None):
 	if not filters:
 		filters = {}
 
-	from_date = get_first_day(filters["month"] + "-" + filters["year"])
-	to_date = get_last_day(filters["month"] + "-" + filters["year"])
+	filter_year = str(
+		frappe.db.get_value(
+			"Academic Year", {"name": filters["year"]}, fieldname="year_start_date"
+		).year
+	)
+
+	from_date = get_first_day(filters["month"] + "-" + filter_year)
+	to_date = get_last_day(filters["month"] + "-" + filter_year)
+
 	total_days_in_month = date_diff(to_date, from_date) + 1
 	columns = get_columns(total_days_in_month)
 	students = get_student_group_students(filters.get("student_group"), 1)


### PR DESCRIPTION
Currently "Year" Filter in the "Student Monthly Attendance" Report is set to Select type, and its options are rendered via a code block in the "on_load" lifecycle method.

This works perfectly but when we try to create the Auto Email Report from the report , the options of the Filter "Year" is not populated as "on_load" lifecycle method is not triggered, because of which the options are not populated.

**When fieldtype is Select, the options of "Year" are not populated**
<img width="802" alt="Screenshot 2023-11-20 at 3 15 16 PM" src="https://github.com/frappe/education/assets/65544983/626bbb7d-0c71-4487-a597-e8a54dab96b8">


**When fieldtype is Link, the options of "Year" are populated and the Report works like it used to be. **

<img width="804" alt="Screenshot 2023-11-20 at 3 17 54 PM" src="https://github.com/frappe/education/assets/65544983/84784218-c3a2-44d3-aa4d-c52a0ce8d305">


closes
#161

