### PR TITLE
feat: Cancel Previous Enrollments when enrolling in a new Program

### DIFF
--- a/education/education/doctype/education_settings/education_settings.json
+++ b/education/education/doctype/education_settings/education_settings.json
@@ -8,6 +8,7 @@
   "current_academic_year",
   "current_academic_term",
   "attendance_freeze_date",
+  "cancel_previous_enrollments",
   "column_break_4",
   "validate_batch",
   "validate_course",
@@ -76,11 +77,18 @@
    "fieldname": "user_creation_skip",
    "fieldtype": "Check",
    "label": "Skip User creation for new Student"
+  },
+  {
+   "default": "0",
+   "description": "If checked, during the submission of a student's program enrollment, previous program enrollments for that student will be cancelled.",
+   "fieldname": "cancel_previous_enrollments",
+   "fieldtype": "Check",
+   "label": "Cancel Previous Enrollments"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2022-12-12 15:20:54.983137",
+ "modified": "2023-11-27 22:57:47.138816",
  "modified_by": "Administrator",
  "module": "Education",
  "name": "Education Settings",
@@ -115,7 +123,6 @@
   }
  ],
  "quick_entry": 1,
- "restrict_to_domain": "",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/education/education/doctype/program_enrollment/program_enrollment.py
+++ b/education/education/doctype/program_enrollment/program_enrollment.py
@@ -103,7 +103,12 @@ class ProgramEnrollment(Document):
 			},
 		)
 		if enrollment:
-			frappe.throw(_("Student is already enrolled."))
+			# frappe.throw(_("Student is already enrolled."))
+			frappe.throw(
+				_("Student {0} is already enrolled in {1}").format(
+					self.student, get_link_to_form("Program Enrollment", enrollment)
+				)
+			)
 
 	def update_student_joining_date(self):
 		table = frappe.qb.DocType("Program Enrollment")


### PR DESCRIPTION
**Issue:**
Currently we allow student to enroll in Multiple Programs at the same time.
Some requests were there to cancel previous enrollments if a student is enrolled in a new program.

**Solution:**

Add a checkbox ```cancel_previous_enrollments``` in Education Settings. 
If ticked, then while submitting the Program Enrollment, previous enrollment will be cancelled.