### PR TITLE
fix(UX): Navigate between rows using "Enter" & "Tab" in Assessment Result Tool

### DIFF
--- a/education/education/doctype/assessment_result_tool/assessment_result_tool.js
+++ b/education/education/doctype/assessment_result_tool/assessment_result_tool.js
@@ -75,27 +75,29 @@ frappe.ui.form.on('Assessment Result Tool', {
 		result_table.appendTo(frm.fields_dict.result_html.wrapper);
 
 		$(".assessment-criteria").on("keydown",function (e) {
-			// get row index
-			// index [1] of classList is row along with criteria's index suffix
-			// .match for number extraction
-			let rowIndex = Number(e.target.parentElement.classList[1].match(/\d+/)[0]);
+			// get data-criteria attribute
+			let criteriaIndex = cint(e.target.parentElement.getAttribute('data-criteria-index'));
+			changeFocusToNextCell(e, 2 + criteriaIndex)
+		})
+
+		$(".result-comment").on("keydown",function (e) {
+			changeFocusToNextCell(e, 5)
+		})
+
+		function changeFocusToNextCell (e,cellIndex) {
 			if (e.keyCode === 13 && !e.shiftKey) {
 				let nextRow = e.target.parentElement.parentElement.nextElementSibling;
 				if (nextRow) {
-					// first 2 columns are student name and ID so add 2
-					nextRow.cells[2+rowIndex].lastElementChild.focus()
+					nextRow.cells[cellIndex].lastElementChild.focus()
 				}
 			}
-
 			if (e.keyCode === 13 && e.shiftKey) {
 				let prevRow = e.target.parentElement.parentElement.previousElementSibling;
-				// first 2 columns are student name and ID so add 2
 				if (prevRow) {
-					prevRow.cells[2+rowIndex].lastElementChild.focus()
+					prevRow.cells[cellIndex].lastElementChild.focus()
 				}
 			}
-
-		})
+		}
 
 		result_table.on('change', 'input', function(e) {
 			let $input = $(e.target);

--- a/education/education/doctype/assessment_result_tool/assessment_result_tool.js
+++ b/education/education/doctype/assessment_result_tool/assessment_result_tool.js
@@ -74,6 +74,23 @@ frappe.ui.form.on('Assessment Result Tool', {
 		}));
 		result_table.appendTo(frm.fields_dict.result_html.wrapper);
 
+		$(".assessment-criteria").on("keydown",function (e) {
+			if (e.keyCode === 13) {
+				e.preventDefault();
+				// get row index
+				// index [1] of classList is row along with criteria's index suffix
+				// .match for number extraction
+				let rowIndex = Number(e.target.parentElement.classList[1].match(/\d+/)[0]);
+				let nextRow = e.target.parentElement.parentElement.nextElementSibling;
+				// first 2 columns are student name and ID so add 2
+				if (nextRow) {
+					nextRow.cells[2+rowIndex].lastElementChild.focus()
+				}
+			}
+
+			let currentRow = e.target.parentElement;
+		})
+
 		result_table.on('change', 'input', function(e) {
 			let $input = $(e.target);
 			let student = $input.data().student;

--- a/education/education/doctype/assessment_result_tool/assessment_result_tool.js
+++ b/education/education/doctype/assessment_result_tool/assessment_result_tool.js
@@ -75,12 +75,11 @@ frappe.ui.form.on('Assessment Result Tool', {
 		result_table.appendTo(frm.fields_dict.result_html.wrapper);
 
 		$(".assessment-criteria").on("keydown",function (e) {
-			if (e.keyCode === 13) {
-				e.preventDefault();
-				// get row index
-				// index [1] of classList is row along with criteria's index suffix
-				// .match for number extraction
-				let rowIndex = Number(e.target.parentElement.classList[1].match(/\d+/)[0]);
+			// get row index
+			// index [1] of classList is row along with criteria's index suffix
+			// .match for number extraction
+			let rowIndex = Number(e.target.parentElement.classList[1].match(/\d+/)[0]);
+			if (e.keyCode === 13 && !e.shiftKey) {
 				let nextRow = e.target.parentElement.parentElement.nextElementSibling;
 				// first 2 columns are student name and ID so add 2
 				if (nextRow) {
@@ -88,7 +87,14 @@ frappe.ui.form.on('Assessment Result Tool', {
 				}
 			}
 
-			let currentRow = e.target.parentElement;
+			if (e.keyCode === 13 && e.shiftKey) {
+				let prevRow = e.target.parentElement.parentElement.previousElementSibling;
+				// first 2 columns are student name and ID so add 2
+				if (prevRow) {
+					prevRow.cells[2+rowIndex].lastElementChild.focus()
+				}
+			}
+
 		})
 
 		result_table.on('change', 'input', function(e) {

--- a/education/education/doctype/assessment_result_tool/assessment_result_tool.js
+++ b/education/education/doctype/assessment_result_tool/assessment_result_tool.js
@@ -81,8 +81,8 @@ frappe.ui.form.on('Assessment Result Tool', {
 			let rowIndex = Number(e.target.parentElement.classList[1].match(/\d+/)[0]);
 			if (e.keyCode === 13 && !e.shiftKey) {
 				let nextRow = e.target.parentElement.parentElement.nextElementSibling;
-				// first 2 columns are student name and ID so add 2
 				if (nextRow) {
+					// first 2 columns are student name and ID so add 2
 					nextRow.cells[2+rowIndex].lastElementChild.focus()
 				}
 			}

--- a/education/public/js/assessment_result_tool.html
+++ b/education/public/js/assessment_result_tool.html
@@ -26,7 +26,7 @@
 			<td>{{ s.student }}</td>
 			<td>{{ s.student_name }}</td>
 			{% for c in criteria %}
-			<td>
+			<td class="assessment-criteria assessment-criteria{{c._index}}">
 				<span data-student="{{s.student}}" data-criteria="{{c.assessment_criteria}}" class="student-result-grade badge" >
 					{% if(s.assessment_details) { %}
 						{{s.assessment_details[c.assessment_criteria][1]}}

--- a/education/public/js/assessment_result_tool.html
+++ b/education/public/js/assessment_result_tool.html
@@ -26,7 +26,7 @@
 			<td>{{ s.student }}</td>
 			<td>{{ s.student_name }}</td>
 			{% for c in criteria %}
-			<td class="assessment-criteria assessment-criteria{{c._index}}">
+			<td class="assessment-criteria" data-criteria-index="{{c._index}}">
 				<span data-student="{{s.student}}" data-criteria="{{c.assessment_criteria}}" class="student-result-grade badge" >
 					{% if(s.assessment_details) { %}
 						{{s.assessment_details[c.assessment_criteria][1]}}


### PR DESCRIPTION
Currently while entering marks using "Assessment Result Tool", we can navigate between the row only using "Tab Button"(as shown in the below video): 

https://github.com/frappe/education/assets/65544983/bb9d4994-69c4-42ed-9c64-eb066629c4ae

**Enhancement:**

Navigate between rows using "Enter" & "Tab" 


https://github.com/frappe/education/assets/65544983/d6c0ae85-bd5e-4ef8-852e-996881c6bbeb



