### PR TITLE
fix: migration issue due to oldfieldname column

### DIFF
--- a/education/education/doctype/fee_category/fee_category.json
+++ b/education/education/doctype/fee_category/fee_category.json
@@ -18,8 +18,6 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Name",
-   "oldfieldname": "earning_name",
-   "oldfieldtype": "Data",
    "reqd": 1,
    "unique": 1
   },
@@ -28,8 +26,6 @@
    "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Description",
-   "oldfieldname": "description",
-   "oldfieldtype": "Small Text",
    "width": "300px"
   },
   {

--- a/education/education/doctype/fee_component/fee_component.json
+++ b/education/education/doctype/fee_component/fee_component.json
@@ -21,8 +21,6 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Fees Category",
-   "oldfieldname": "earning_name",
-   "oldfieldtype": "Data",
    "options": "Fee Category",
    "reqd": 1
   },
@@ -42,8 +40,6 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Amount",
-   "oldfieldname": "description",
-   "oldfieldtype": "Small Text",
    "reqd": 1,
    "width": "300px"
   },
@@ -58,7 +54,7 @@
   {
    "default": "0",
    "fieldname": "discount",
-   "fieldtype": "Percent",
+   "fieldtype": "FLoat",
    "in_list_view": 1,
    "label": "Discount(%)"
   },

--- a/education/education/doctype/fee_structure/fee_structure.json
+++ b/education/education/doctype/fee_structure/fee_structure.json
@@ -44,8 +44,6 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Program",
-   "oldfieldname": "earning_name",
-   "oldfieldtype": "Data",
    "options": "Program",
    "reqd": 1,
    "search_index": 1
@@ -66,8 +64,6 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Academic Term",
-   "oldfieldname": "description",
-   "oldfieldtype": "Small Text",
    "options": "Academic Term",
    "search_index": 1,
    "width": "300px"


### PR DESCRIPTION
Got this error while migrating.

pymysql.err.DataError: (1265, "Data truncated for column 'discount' at row 1")