### PR TITLE
fix: remove translation call from hooks.py and convert discount to float while validating discount

### DIFF
--- a/education/education/doctype/fee_structure/fee_structure.py
+++ b/education/education/doctype/fee_structure/fee_structure.py
@@ -25,7 +25,7 @@ class FeeStructure(Document):
 
 	def validate_discount(self):
 		for component in self.components:
-			if component.discount > 100:
+			if flt(component.discount) > 100:
 				frappe.throw(
 					_("Discount cannot be greater than 100%  in row {0}").format(component.idx)
 				)

--- a/education/hooks.py
+++ b/education/hooks.py
@@ -45,7 +45,7 @@ calendars = [
 
 standard_portal_menu_items = [
 	{
-		"title": _("Admission"),
+		"title": "Admission",
 		"route": "/admissions",
 		"reference_doctype": "Student Admission",
 		"role": "Student",


### PR DESCRIPTION
fixes the errors shown below

1. 
![telegram-cloud-photo-size-5-6167849306988591238-y](https://github.com/frappe/education/assets/65544983/451a8403-3170-476e-aafc-578b876744eb)

2. 
<img width="1440" alt="Screenshot 2024-01-26 at 3 08 55 PM" src="https://github.com/frappe/education/assets/65544983/d682553e-115f-4cec-88ae-8bd03a963194">

