### PR TITLE
fix: when no term is found for an academic year while choosing fee plan throw an error

### DIFF
--- a/education/education/doctype/fee_structure/fee_structure.py
+++ b/education/education/doctype/fee_structure/fee_structure.py
@@ -91,6 +91,10 @@ def get_amount_distribution_based_on_fee_plan(
 			fields=["name", "term_start_date"],
 			order_by="term_start_date asc",
 		)
+		if not academic_terms:
+			frappe.throw(
+				_("No Academic Terms found for Academic Year {0}").format(academic_year)
+			)
 		month_dict.get(fee_plan)["amount"] = 1 / len(academic_terms)
 
 		for term in academic_terms:


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2024-01-26 at 7 18 36 PM" src="https://github.com/frappe/education/assets/65544983/934df179-8ada-4f17-888d-7af5e96e128d">

We get this error when there the fee plan is selected as "Term-Wise" and there are no academic terms linked to a particular academic year.


