### PR TITLE
fix: remove translations from hooks.py

### DIFF
--- a/education/hooks.py
+++ b/education/hooks.py
@@ -1,5 +1,3 @@
-from frappe import _
-
 from . import __version__ as app_version
 
 app_name = "education"
@@ -44,7 +42,7 @@ calendars = [
 ]
 
 standard_portal_menu_items = [
-	{"title": _("Fees"), "route": "/fees", "reference_doctype": "Fees", "role": "Student"},
+	{"title": "Fees", "route": "/fees", "reference_doctype": "Fees", "role": "Student"},
 	{
 		"title": _("Admission"),
 		"route": "/admissions",


### PR DESCRIPTION
We get circular import error when we use translations in hooks.py file.
This PR solves the issue by removing "_" which is used from translations from hooks.py file.