### PR TITLE
fix: change get_list to get_all for child doctype v-15

### DIFF
--- a/education/education/doctype/student_leave_application/student_leave_application.py
+++ b/education/education/doctype/student_leave_application/student_leave_application.py
@@ -142,7 +142,7 @@ def get_number_of_leave_days(from_date, to_date, holiday_list):
 
 @frappe.whitelist()
 def get_student_groups(student):
-	student_group = frappe.db.get_list(
+	student_group = frappe.db.get_all(
 		"Student Group Student",
 		pluck="parent",
 		filters={"student": student},


### PR DESCRIPTION
While accessing "Student Group Student" child doctype we get the following error.



<img width="1261" alt="Screenshot 2024-02-09 at 2 40 45 PM" src="https://github.com/frappe/education/assets/65544983/f99121ff-3207-4f36-8f6c-f5e93a06f29a">


**Reason:**

we were using get_list instead of get_all

