### PR TITLE
fix: show attendance w.r.t years instead of academic year

### DIFF
--- a/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.js
+++ b/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.js
@@ -15,8 +15,8 @@ frappe.query_reports["Student Monthly Attendance Sheet"] = {
 	{
 		"fieldname": "year",
 		"label": __("Year"),
-		"fieldtype": "Link",
-		"options":"Academic Year",
+		"fieldtype": "Select",
+		"options":"",
 		"reqd": 1
 	},
 	{
@@ -27,4 +27,17 @@ frappe.query_reports["Student Monthly Attendance Sheet"] = {
 		"reqd": 1
 	}
 	],
+	onload: function() {
+		return  frappe.call({
+			// method: "hrms.hr.report.monthly_attendance_sheet.monthly_attendance_sheet.get_attendance_years",
+			method: "education.education.report.student_monthly_attendance_sheet.student_monthly_attendance_sheet.get_year_list",
+			callback: function(r) {
+				let year_filter = frappe.query_report.get_filter('year');
+				year_filter.df.options = r.message;
+				year_filter.df.default = r.message.join("\n");
+				year_filter.refresh();
+				year_filter.set_input(year_filter.df.default);
+			}
+		});
+	},
 }

--- a/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
+++ b/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
@@ -159,3 +159,13 @@ def mark_holidays(att_map, from_date, to_date, students_list):
 				att_map.setdefault(student, frappe._dict()).setdefault(dt, "Holiday")
 
 	return att_map
+
+@frappe.whitelist()
+def get_year_list():
+	all_academic_years = frappe.db.get_list("Academic Year", pluck="year_start_date")
+
+	year_list = [date.year for date in all_academic_years]
+	year_list = list(set(year_list))
+	year_list.sort()
+
+	return year_list

--- a/education/hooks.py
+++ b/education/hooks.py
@@ -1,5 +1,3 @@
-from frappe import _
-
 from . import __version__ as app_version
 
 app_name = "education"
@@ -44,7 +42,7 @@ calendars = [
 ]
 
 standard_portal_menu_items = [
-	{"title": _("Fees"), "route": "/fees", "reference_doctype": "Fees", "role": "Student"},
+	{"title": "Fees", "route": "/fees", "reference_doctype": "Fees", "role": "Student"},
 	{
 		"title": _("Admission"),
 		"route": "/admissions",


### PR DESCRIPTION
**Currently:**
<img width="1307" alt="Screenshot 2024-03-12 at 12 43 06 PM" src="https://github.com/frappe/education/assets/65544983/ceab5756-3a4d-4335-a8fa-f3496774fb9e">

In the report "Student Monthly Attendance Sheet"

we select "academic year" and a month, and then in code we take the year_start_date from the academic year.
Which gives us incorrect data

For e.g.

The attendance is marked on 2024 March, but the academic year is 2023-2024 which starts from "April 23" and end on "March 24"

So instead of taking 'March Year 24',  current code will take 'March Year 23' .

**Solution**
<img width="1329" alt="Screenshot 2024-03-12 at 12 48 01 PM" src="https://github.com/frappe/education/assets/65544983/5ed0757f-23f8-468a-b0b6-4a074d44907a">

Ask for Year instead of Academic Year in the filters.


