### PR TITLE
fix: show attendance w.r.t years instead of academic year

### DIFF
--- a/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.js
+++ b/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.js
@@ -15,8 +15,8 @@ frappe.query_reports["Student Monthly Attendance Sheet"] = {
 	{
 		"fieldname": "year",
 		"label": __("Year"),
-		"fieldtype": "Link",
-		"options":"Academic Year",
+		"fieldtype": "Select",
+		"options":"",
 		"reqd": 1
 	},
 	{
@@ -27,4 +27,17 @@ frappe.query_reports["Student Monthly Attendance Sheet"] = {
 		"reqd": 1
 	}
 	],
+	onload: function() {
+		return  frappe.call({
+			// method: "hrms.hr.report.monthly_attendance_sheet.monthly_attendance_sheet.get_attendance_years",
+			method: "education.education.report.student_monthly_attendance_sheet.student_monthly_attendance_sheet.get_year_list",
+			callback: function(r) {
+				let year_filter = frappe.query_report.get_filter('year');
+				year_filter.df.options = r.message;
+				year_filter.df.default = r.message.join("\n");
+				year_filter.refresh();
+				year_filter.set_input(year_filter.df.default);
+			}
+		});
+	},
 }

--- a/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
+++ b/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
@@ -17,15 +17,8 @@ def execute(filters=None):
 	if not filters:
 		filters = {}
 
-	filter_year = str(
-		frappe.db.get_value(
-			"Academic Year", {"name": filters["year"]}, fieldname="year_start_date"
-		).year
-	)
-
-	from_date = get_first_day(filters["month"] + "-" + filter_year)
-	to_date = get_last_day(filters["month"] + "-" + filter_year)
-
+	from_date = get_first_day(filters["month"] + "-" + filters["year"])
+	to_date = get_last_day(filters["month"] + "-" + filters["year"])
 	total_days_in_month = date_diff(to_date, from_date) + 1
 	columns = get_columns(total_days_in_month)
 	students = get_student_group_students(filters.get("student_group"), 1)
@@ -33,7 +26,6 @@ def execute(filters=None):
 	att_map = get_attendance_list(
 		from_date, to_date, filters.get("student_group"), students_list
 	)
-	print(att_map)
 	data = []
 
 	for stud in students:
@@ -69,7 +61,6 @@ def execute(filters=None):
 
 		row += [total_p, total_a]
 		data.append(row)
-		print(data)
 	return columns, data
 
 
@@ -161,3 +152,14 @@ def mark_holidays(att_map, from_date, to_date, students_list):
 				att_map.setdefault(student, frappe._dict()).setdefault(dt, "Holiday")
 
 	return att_map
+
+
+@frappe.whitelist()
+def get_year_list():
+	all_academic_years = frappe.db.get_list("Academic Year", pluck="year_start_date")
+
+	year_list = [date.year for date in all_academic_years]
+	year_list = list(set(year_list))
+	year_list.sort()
+
+	return year_list


### PR DESCRIPTION
**Currently:**
<img width="1307" alt="Screenshot 2024-03-12 at 12 43 06 PM" src="https://github.com/frappe/education/assets/65544983/ceab5756-3a4d-4335-a8fa-f3496774fb9e">

In the report "Student Monthly Attendance Sheet"

we select "academic year" and a month, and then in code we take the year_start_date from the academic year.
Which gives us incorrect data

For e.g.

The attendance is marked on 2024 March, but the academic year is 2023-2024 which starts from "April 23" and end on "March 24"

So instead of taking 'March Year 24',  current code will take 'March Year 23' .

**Solution**
<img width="1329" alt="Screenshot 2024-03-12 at 12 48 01 PM" src="https://github.com/frappe/education/assets/65544983/5ed0757f-23f8-468a-b0b6-4a074d44907a">

Ask for Year instead of Academic Year in the filters.
