### PR TITLE
fix: edge case where year_start_date is not present in academic year

### DIFF
--- a/education/education/api.py
+++ b/education/education/api.py
@@ -618,9 +618,6 @@ def apply_leave_based_on_course_schedule(leave_data, program_name):
 		},
 		order_by="schedule_date asc",
 	)
-	print("-------------------")
-	print(course_schedule_in_leave_period)
-	print("-------------------")
 
 	if frappe.db.exists("Student Attendance", {"course_schedule": "EDU-CSH-2024-00003"}):
 		pass

--- a/education/education/doctype/student_leave_application/student_leave_application.py
+++ b/education/education/doctype/student_leave_application/student_leave_application.py
@@ -71,7 +71,6 @@ class StudentLeaveApplication(Document):
 			},
 			fields=["name"],
 		)
-		print("leave_classes", leave_classes)
 
 		holiday_list = get_holiday_list()
 

--- a/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
+++ b/education/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
@@ -158,7 +158,7 @@ def mark_holidays(att_map, from_date, to_date, students_list):
 def get_year_list():
 	all_academic_years = frappe.db.get_list("Academic Year", pluck="year_start_date")
 
-	year_list = [date.year for date in all_academic_years]
+	year_list = [date.year for date in all_academic_years if date]
 	year_list = list(set(year_list))
 	year_list.sort()
 


### PR DESCRIPTION
**Problem**
when finding academic years, if year_start_date is not set then we get an arror
<img width="1302" alt="Screenshot 2024-03-13 at 12 36 09 PM" src="https://github.com/frappe/education/assets/65544983/c314843a-66ed-41af-996b-dc0a399c472e">


**Fix:**
Check whether the data received exists or not, if it is None filter it out
