### PR TITLE
fix: add patch for sales invoice permission and parent assessment group

### DIFF
--- a/education/patches.txt
+++ b/education/patches.txt
@@ -9,3 +9,5 @@ education.patches.v14_0.delete_lms_user_role
 education.patches.v15_0.fees_student_email
 education.patches.v15_0.student_role_desk_access
 education.patches.v15_0.sales_invoice_student_field
+education.patches.v15_0.create_parent_assessment_group
+education.patches.v15_0.student_role_permission_sales_invoice

--- a/education/patches/v15_0/create_parent_assessment_group.py
+++ b/education/patches/v15_0/create_parent_assessment_group.py
@@ -1,0 +1,6 @@
+import frappe
+from education.install import create_parent_assessment_group
+
+
+def execute():
+	create_parent_assessment_group()

--- a/education/patches/v15_0/student_role_permission_sales_invoice.py
+++ b/education/patches/v15_0/student_role_permission_sales_invoice.py
@@ -1,0 +1,18 @@
+import frappe
+from frappe.permissions import add_permission, update_permission_property
+
+
+def execute():
+
+	add_permission("Sales Invoice", "Student", 0)
+
+	doctype = "Sales Invoice"
+	role = "Student"
+	permlevel = 0
+	ptype = ["read", "write", "print"]
+
+	for p in ptype:
+		# update permissions
+		update_permission_property(doctype, role, permlevel, p, 1)
+
+	frappe.db.commit()


### PR DESCRIPTION
**Add patch for** 
1. Giving Student Role Permission to read/write/print the Sales Invoice DocType
2. Creating Parent Assessment Group called "All Assessment Groups". 

**fixes:**
- https://discuss.frappe.io/t/assessment-group-not-create/119438
- https://discuss.frappe.io/t/i-am-facing-a-difficulty-while-creating-assessment-group/119440
