### PR TITLE
fix: filter for fee_structure in fee_schedule

### DIFF
--- a/education/education/doctype/fee_schedule/fee_schedule.js
+++ b/education/education/doctype/fee_schedule/fee_schedule.js
@@ -29,6 +29,14 @@ frappe.ui.form.on("Fee Schedule", {
 			};
 		});
 
+		frm.set_query("fee_structure", () => {
+			return {
+				filters: {
+					docstatus: 1,
+				},
+			};
+		})
+
 		frm.set_query("academic_term", function (doc) {
 			return {
 				filters: {


### PR DESCRIPTION
**Description:**
In fee schedule we are able to link Fee Structures which are not even submitted. We shouldn't allow this.

**Fix:** 
Add frm.set_query on "Fee Structure" field in Fee Schedule DocType.
  
  <img width="1363" alt="Screenshot 2024-04-01 at 11 11 21 PM" src="https://github.com/frappe/education/assets/65544983/fcf6f5f8-5e0f-4b18-9301-ddd8b198022d">
