### PR TITLE
fix: filter course schedule based on student group

### DIFF
--- a/education/education/api.py
+++ b/education/education/api.py
@@ -574,7 +574,9 @@ def get_course_list_based_on_program(program_name):
 
 
 @frappe.whitelist()
-def get_course_schedule_for_student(program_name):
+def get_course_schedule_for_student(program_name, student_groups):
+	student_groups = [sg.get("label") for sg in student_groups]
+
 	schedule = frappe.db.get_list(
 		"Course Schedule",
 		fields=[
@@ -588,7 +590,7 @@ def get_course_schedule_for_student(program_name):
 			"title",
 			"name",
 		],
-		filters={"program": program_name},
+		filters={"program": program_name, "student_group": ["in", student_groups]},
 		order_by="schedule_date asc",
 	)
 	return schedule

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -1,27 +1,30 @@
 <template>
-	<div class="w-full h-full">
+  <div class="w-full h-full">
     <Calendar
       v-if="!scheduleResource.loading && scheduleResource.data"
       :events="events"
     />
-	</div>
+  </div>
 </template>
 
 <script setup>
 import Calendar from '@/components/Calendar.vue'
-import { createResource } from 'frappe-ui';
-import {ref} from 'vue'
-import { studentStore } from '@/stores/student';
-const { getCurrentProgram } = studentStore()
+import { createResource } from 'frappe-ui'
+import { ref } from 'vue'
+import { studentStore } from '@/stores/student'
+const { getCurrentProgram, getStudentGroups } = studentStore()
 
 const programName = ref(getCurrentProgram()?.value?.program)
-const events= ref([])
-
+const studentGroup = ref(getStudentGroups().value)
+const events = ref([])
 
 const scheduleResource = createResource({
-  url:"education.education.api.get_course_schedule_for_student",
-  params: {program_name:programName.value},
-  onSuccess:(response) => {
+  url: 'education.education.api.get_course_schedule_for_student',
+  params: {
+    program_name: programName.value,
+    student_groups: studentGroup.value,
+  },
+  onSuccess: (response) => {
     let schedule = []
     response.forEach((classSchedule) => {
       schedule.push({
@@ -30,17 +33,15 @@ const scheduleResource = createResource({
         name: classSchedule.name,
         room: classSchedule.room,
         date: classSchedule.schedule_date,
-        from_time: classSchedule.from_time.split(".")[0],
-        to_time: classSchedule.to_time.split(".")[0],
-        color: classSchedule.class_schedule_color
+        from_time: classSchedule.from_time.split('.')[0],
+        to_time: classSchedule.to_time.split('.')[0],
+        color: classSchedule.class_schedule_color,
       })
     })
     events.value = schedule
   },
-  auto:true
+  auto: true,
 })
-
 </script>
 
-<style>
-</style>
+<style></style>


### PR DESCRIPTION
**Currently**
In the portal we get course schedule regardless of the student group the student is enrolled in.

**Reason:**
Student Group filter was not applied in ```get_course_schedule_for_student```.

**Solution:**
Send student group from the student store to the api, and filter course schedule based on group and program