### PR TITLE
fix: add permission for student to read invoices in portal

### DIFF
--- a/education/install.py
+++ b/education/install.py
@@ -1,12 +1,14 @@
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.desk.page.setup_wizard.setup_wizard import make_records
+from frappe.permissions import add_permission, update_permission_property
 
 
 def after_install():
 	setup_fixtures()
 	create_student_role()
 	create_parent_assessment_group()
+	create_invoice_permissions()
 	create_custom_fields(get_custom_fields())
 
 
@@ -36,6 +38,19 @@ def create_parent_assessment_group():
 def create_student_role():
 	if not frappe.db.exists("Role", "Student"):
 		frappe.get_doc({"doctype": "Role", "role_name": "Student", "desk_access": 0}).save()
+
+
+def create_invoice_permissions():
+	add_permission("Sales Invoice", "Student", 0)
+
+	doctype = "Sales Invoice"
+	role = "Student"
+	permlevel = 0
+	ptype = ["read", "write", "print"]
+
+	for p in ptype:
+		# update permissions
+		update_permission_property(doctype, role, permlevel, p, 1)
 
 
 def get_custom_fields():


### PR DESCRIPTION
While installing Education, add permission for student to read sales invoices, which will be shown in the "Student Portal".