### PR TITLE
fix: add permissions for academic user

### DIFF
--- a/education/install.py
+++ b/education/install.py
@@ -10,6 +10,7 @@ def after_install():
 	create_parent_assessment_group()
 	create_invoice_permissions()
 	create_custom_fields(get_custom_fields())
+	create_permissions(get_permissions())
 
 
 def setup_fixtures():
@@ -51,6 +52,40 @@ def create_invoice_permissions():
 	for p in ptype:
 		# update permissions
 		update_permission_property(doctype, role, permlevel, p, 1)
+
+
+def get_permissions():
+	return [
+		{
+			"doctype": "Sales Invoice",
+			"role": "Student",
+			"permlevel": 0,
+			"ptype": ["read", "write", "print"],
+		},
+		{
+			"doctype": "User",
+			"role": "Academics User",
+			"permlevel": 0,
+			"ptype": ["read", "write", "create"],
+		},
+		{
+			"doctype": "Customer",
+			"role": "Academics User",
+			"permlevel": 0,
+			"ptype": ["read", "write", "create"],
+		},
+	]
+
+
+def create_permissions(doctype_permissions):
+	for doctype_permission in doctype_permissions:
+		doctype = doctype_permission.get("doctype")
+		role = doctype_permission.get("role")
+		permlevel = doctype_permission.get("permlevel")
+		ptype = doctype_permission.get("ptype")
+		add_permission(doctype, role, permlevel)
+		for p in ptype:
+			update_permission_property(doctype, role, permlevel, p, 1)
 
 
 def get_custom_fields():

--- a/education/patches.txt
+++ b/education/patches.txt
@@ -15,3 +15,4 @@ education.patches.v15_0.sales_order_student_field
 education.patches.v15_0.fee_schedule_status_update #28-03-2024
 education.patches.v15_0.create_fee_component_item_group
 education.patches.v15_0.create_student_customer_group
+education.patches.v15_0.create_custom_permissions


### PR DESCRIPTION
**Issue:**
While Enrolling students from "Program Enrollment", user with the role of "Academics User", was unable to to enroll the student as the user did not have permission to create a new user and customer.

**Solution:**
1.  For old users, wrote a patch for adding the above permissions.
2. For new users, the permissions will be added while installing the app.