### PR TITLE
feat: customise fee plans

### DIFF
--- a/education/education/doctype/fee_schedule/fee_schedule.js
+++ b/education/education/doctype/fee_schedule/fee_schedule.js
@@ -3,167 +3,186 @@
 
 frappe.provide("erpnext.accounts.dimensions");
 frappe.ui.form.on("Fee Schedule", {
-	company: function (frm) {
-		erpnext.accounts.dimensions.update_dimension(frm, frm.doctype);
-	},
+  company: function (frm) {
+    erpnext.accounts.dimensions.update_dimension(frm, frm.doctype);
+  },
 
+  onload: function (frm) {
+    frm.set_query("receivable_account", function (doc) {
+      return {
+        filters: {
+          account_type: "Receivable",
+          is_group: 0,
+          company: doc.company,
+        },
+      };
+    });
 
-	onload: function (frm) {
-		frm.set_query("receivable_account", function (doc) {
-			return {
-				filters: {
-					account_type: "Receivable",
-					is_group: 0,
-					company: doc.company,
-				},
-			};
-		});
+    frm.set_query("income_account", function (doc) {
+      return {
+        filters: {
+          account_type: "Income Account",
+          is_group: 0,
+          company: doc.company,
+        },
+      };
+    });
 
-		frm.set_query("income_account", function (doc) {
-			return {
-				filters: {
-					account_type: "Income Account",
-					is_group: 0,
-					company: doc.company,
-				},
-			};
-		});
+    frm.set_query("fee_structure", () => {
+      return {
+        filters: {
+          docstatus: 1,
+        },
+      };
+    });
 
-		frm.set_query("fee_structure", () => {
-			return {
-				filters: {
-					docstatus: 1,
-				},
-			};
-		})
+    frm.set_query("academic_term", function (doc) {
+      return {
+        filters: {
+          academic_year: doc.academic_year,
+        },
+      };
+    });
 
-		frm.set_query("academic_term", function (doc) {
-			return {
-				filters: {
-					academic_year: doc.academic_year,
-				},
-			};
-		});
+    frm.set_query("student_group", "student_groups", function () {
+      return {
+        filters: {
+          program: frm.doc.program,
+          academic_term: frm.doc.academic_term,
+          academic_year: frm.doc.academic_year,
+          disabled: 0,
+        },
+      };
+    });
 
-		frm.set_query("student_group", "student_groups", function () {
-			return {
-				filters: {
-					program: frm.doc.program,
-					academic_term: frm.doc.academic_term,
-					academic_year: frm.doc.academic_year,
-					disabled: 0,
-				},
-			};
-		});
+    frappe.realtime.on("fee_schedule_progress", function (data) {
+      if (data.reload && data.reload === 1) {
+        frm.reload_doc();
+      }
+      if (data.progress) {
+        let progress_bar = $(cur_frm.dashboard.progress_area.body).find(
+          ".progress-bar"
+        );
+        if (progress_bar) {
+          $(progress_bar)
+            .removeClass("progress-bar-danger")
+            .addClass("progress-bar-success progress-bar-striped");
+          $(progress_bar).css("width", data.progress + "%");
+        }
+      }
+    });
 
-		frappe.realtime.on("fee_schedule_progress", function (data) {
-			if (data.reload && data.reload === 1) {
-				frm.reload_doc();
-			}
-			if (data.progress) {
-				let progress_bar = $(cur_frm.dashboard.progress_area.body).find(
-					".progress-bar"
-				);
-				if (progress_bar) {
-					$(progress_bar)
-						.removeClass("progress-bar-danger")
-						.addClass("progress-bar-success progress-bar-striped");
-					$(progress_bar).css("width", data.progress + "%");
-				}
-			}
-		});
+    erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
+  },
 
-		erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
-	},
+  refresh: function (frm) {
+    if (
+      !frm.doc.__islocal &&
+      frm.doc.__onload &&
+      frm.doc.__onload.dashboard_info &&
+      (frm.doc.status === "Order Created" ||
+        frm.doc.status === "Invoice Created")
+    ) {
+      var info = frm.doc.__onload.dashboard_info;
+      frm.dashboard.add_indicator(
+        __("Total Collected: {0}", [
+          format_currency(info.total_paid, info.currency),
+        ]),
+        "blue"
+      );
+      frm.dashboard.add_indicator(
+        __("Total Outstanding: {0}", [
+          format_currency(info.total_unpaid, info.currency),
+        ]),
+        info.total_unpaid ? "orange" : "green"
+      );
+    }
+    if (frm.doc.status === "In Process") {
+      frm.dashboard.add_progress("Fee Creation Status", "0");
+    }
+    if (frm.doc.docstatus === 1 || frm.doc.status === "Failed") {
+      let button_label = "Create Sales Invoice";
 
-	refresh: function (frm) {
-		if (
-			!frm.doc.__islocal &&
-			frm.doc.__onload &&
-			frm.doc.__onload.dashboard_info &&
-			(frm.doc.status === "Order Created" || frm.doc.status === "Invoice Created")
-		) {
-			var info = frm.doc.__onload.dashboard_info;
-			frm.dashboard.add_indicator(
-				__("Total Collected: {0}", [
-					format_currency(info.total_paid, info.currency),
-				]),
-				"blue"
-			);
-			frm.dashboard.add_indicator(
-				__("Total Outstanding: {0}", [
-					format_currency(info.total_unpaid, info.currency),
-				]),
-				info.total_unpaid ? "orange" : "green"
-			);
-		}
-		if (frm.doc.status === "In Process") {
-			frm.dashboard.add_progress("Fee Creation Status", "0");
-		}
-		if (
-			(frm.doc.docstatus === 1) ||
-			frm.doc.status === "Failed"
-		) {
-			let button_label = "Create Sales Invoice";
+      frappe.db.get_value("Education Settings", {}, "create_so", (r) => {
+        // convert r.create_so to number
+        if (+r.create_so) {
+          button_label = "Create Sales Order";
+          // set indicator in the frm
+        }
+        if (
+          frm.doc.status === "Order Pending" ||
+          frm.doc.status === "Invoice Pending"
+        ) {
+          frm.add_custom_button(__(button_label), function () {
+            frappe.call({
+              method: "create_fees",
+              doc: frm.doc,
+              callback: function () {
+                frm.refresh();
+              },
+            });
+          });
+        }
+      });
+    }
+  },
 
-			frappe.db.get_value("Education Settings", {}, "create_so", (r) => {
-				// convert r.create_so to number
-				if (+r.create_so) {
-					button_label = "Create Sales Order";
-					// set indicator in the frm
-				}
-				if (frm.doc.status === "Order Pending" || frm.doc.status === "Invoice Pending") {
-					frm.add_custom_button(__(button_label), function () {
-						frappe.call({
-							method: "create_fees",
-							doc: frm.doc,
-							callback: function () {
-								frm.refresh();
-							},
-						});
-					});
-				}
-			});
-		}
-	},
-
-	fee_structure: function (frm) {
-		if (frm.doc.fee_structure) {
-			frappe.call({
-				method:
-					"education.education.doctype.fee_schedule.fee_schedule.get_fee_structure",
-				args: {
-					target_doc: frm.doc.name,
-					source_name: frm.doc.fee_structure,
-				},
-				callback: function (r) {
-					var doc = frappe.model.sync(r.message);
-					frappe.set_route("Form", doc[0].doctype, doc[0].name);
-				},
-			});
-		}
-	},
+  fee_structure: function (frm) {
+    if (frm.doc.fee_structure) {
+      frappe.call({
+        method:
+          "education.education.doctype.fee_schedule.fee_schedule.get_fee_structure",
+        args: {
+          target_doc: frm.doc.name,
+          source_name: frm.doc.fee_structure,
+        },
+        callback: function (r) {
+          var doc = frappe.model.sync(r.message);
+          frappe.set_route("Form", doc[0].doctype, doc[0].name);
+        },
+      });
+    }
+  },
 });
 
 frappe.ui.form.on("Fee Schedule Student Group", {
-	student_group: function (frm, cdt, cdn) {
-		var row = locals[cdt][cdn];
-		if (row.student_group && frm.doc.academic_year) {
-			frappe.call({
-				method:
-					"education.education.doctype.fee_schedule.fee_schedule.get_total_students",
-				args: {
-					student_group: row.student_group,
-					academic_year: frm.doc.academic_year,
-					academic_term: frm.doc.academic_term,
-					student_category: frm.doc.student_category,
-				},
-				callback: function (r) {
-					if (r.message) {
-						frappe.model.set_value(cdt, cdn, "total_students", r.message);
-					}
-				},
-			});
-		}
-	},
+  student_group: function (frm, cdt, cdn) {
+    var row = locals[cdt][cdn];
+    if (row.student_group && frm.doc.academic_year) {
+      frappe.call({
+        method:
+          "education.education.doctype.fee_schedule.fee_schedule.get_total_students",
+        args: {
+          student_group: row.student_group,
+          academic_year: frm.doc.academic_year,
+          academic_term: frm.doc.academic_term,
+          student_category: frm.doc.student_category,
+        },
+        callback: function (r) {
+          if (r.message) {
+            frappe.model.set_value(cdt, cdn, "total_students", r.message);
+          }
+        },
+      });
+    }
+  },
+});
+
+frappe.ui.form.on("Fee Component", {
+  amount: function (frm, cdt, cdn) {
+    let d = locals[cdt][cdn];
+    d.total = d.amount;
+    refresh_field("components");
+    if (d.discount) {
+      d.total = d.amount - d.amount * (d.discount / 100);
+      refresh_field("components");
+    }
+  },
+  discount: function (frm, cdt, cdn) {
+    let d = locals[cdt][cdn];
+    if (d.discount <= 100) {
+      d.total = d.amount - d.amount * (d.discount / 100);
+    }
+    refresh_field("components");
+  },
 });

--- a/education/education/doctype/fee_schedule/fee_schedule.json
+++ b/education/education/doctype/fee_schedule/fee_schedule.json
@@ -144,8 +144,7 @@
    "fieldname": "components",
    "fieldtype": "Table",
    "label": "Components",
-   "options": "Fee Component",
-   "read_only": 1
+   "options": "Fee Component"
   },
   {
    "fieldname": "section_break_16",
@@ -282,7 +281,7 @@
    "link_fieldname": "fee_schedule"
   }
  ],
- "modified": "2024-05-29 13:48:34.950263",
+ "modified": "2024-07-10 00:17:14.407591",
  "modified_by": "Administrator",
  "module": "Education",
  "name": "Fee Schedule",

--- a/education/education/doctype/fee_schedule/fee_schedule.py
+++ b/education/education/doctype/fee_schedule/fee_schedule.py
@@ -111,13 +111,16 @@ class FeeSchedule(Document):
 				)
 
 	def validate_total_against_fee_strucuture(self):
-		fee_schedules_total = frappe.db.get_all(
-			"Fee Schedule",
-			filters={"fee_structure": self.fee_structure},
-			fields=["sum(total_amount) as total"],
-		)[0]["total"]
-		fee_structure_total = frappe.db.get_value(
-			"Fee Structure", self.fee_structure, "total_amount"
+		fee_schedules_total = (
+			frappe.db.get_all(
+				"Fee Schedule",
+				filters={"fee_structure": self.fee_structure},
+				fields=["sum(total_amount) as total"],
+			)[0]["total"]
+			or 0
+		)
+		fee_structure_total = (
+			frappe.db.get_value("Fee Structure", self.fee_structure, "total_amount") or 0
 		)
 
 		if fee_schedules_total > fee_structure_total:

--- a/education/education/doctype/fee_structure/fee_structure.js
+++ b/education/education/doctype/fee_structure/fee_structure.js
@@ -75,7 +75,8 @@ frappe.ui.form.on("Fee Structure", {
       args: {
         source_name: frm.doc.name,
         dialog_values: frm.dialog.get_values(),
-        per_component_amount: frm.per_component_amount,
+        total_amount: frm.doc.total_amount,
+        per_component_amount: frm.doc.components,
       },
       freeze: true,
       callback: function (r) {

--- a/education/education/doctype/fee_structure/fee_structure.js
+++ b/education/education/doctype/fee_structure/fee_structure.js
@@ -81,7 +81,7 @@ frappe.ui.form.on("Fee Structure", {
       freeze: true,
       callback: function (r) {
         if (r.message) {
-          frappe.msgprint(__("{0} Fee Schedule(s) Create", [r.message]));
+          frappe.msgprint(__("{0} Fee Schedule(s) created", [r.message]));
           frm.dialog.hide();
         }
       },

--- a/education/education/doctype/fee_structure/fee_structure.js
+++ b/education/education/doctype/fee_structure/fee_structure.js
@@ -235,7 +235,7 @@ frappe.ui.form.on("Fee Component", {
   },
   discount: function (frm, cdt, cdn) {
     let d = locals[cdt][cdn];
-    if (d.discount < 100) {
+    if (d.discount <= 100) {
       d.total = d.amount - d.amount * (d.discount / 100);
     }
     refresh_field("components");


### PR DESCRIPTION
**Usecase:**

Alot of times, institutes wants to collect one fee component in only one Fee Schedule and not in other Fee Schedules.
This PR allows user to do the above by allowing the user to add or delete Fee Component in the Fee Schedule DocType.

If a component which is added in Fee Schedule which is not their in the Fee Structure an alert message will be shown to the user.




This PR also fixes 2 issues:
1. **Incorrect date in Fee Plan dialog**: while making fee plan we were getting incorrect dates in the dialog box.

**Before:**

https://github.com/frappe/education/assets/65544983/6f1400a7-f49f-4e92-bfb1-a01ebfecf327



**After:**

https://github.com/frappe/education/assets/65544983/e7f09030-e90f-47a9-b9e5-045befdd6cfe




2. **Custom amount in Fee Plan dialog**: If we used to change the amount in the Fee Plan dialog which is different from the distribution, that amount was never reflected in the Fee Schedule.

**Before:**
All Have same distribution even after adjusting the amount
https://github.com/frappe/education/assets/65544983/4dad6bd3-0f0a-4a36-90f0-fdb546f09246



**After:**
Custom amount is reflected in Fee Schedule

https://github.com/frappe/education/assets/65544983/161e349e-3292-4f68-baef-ae3a2dd51cc4




**What Changed?**
Fee Component table in Fee Schedule DocType is editable now.

**Docs:**
https://docs.frappe.io/education/fee-schedule#2-6-version-15-5-0
