### PR TITLE
fix: use get_all to get data from fee component doctype

### DIFF
--- a/education/education/doctype/fee_schedule/fee_schedule.py
+++ b/education/education/doctype/fee_schedule/fee_schedule.py
@@ -95,7 +95,7 @@ class FeeSchedule(Document):
 	def validate_fee_components(self):
 		fee_schedule_components = [d.fees_category for d in self.components]
 
-		fee_structure_components = frappe.get_list(
+		fee_structure_components = frappe.get_all(
 			"Fee Component",
 			pluck="fees_category",
 			filters={"parent": self.fee_structure},


### PR DESCRIPTION
use frappe.get_all instead of frappe.get_list to get data from Child Table "Fee Component"