### PR TITLE
fix: incorrect toast message

### DIFF
--- a/frontend/src/pages/Attendance.vue
+++ b/frontend/src/pages/Attendance.vue
@@ -153,7 +153,7 @@ const applyLeave = createResource({
     isAttendancePage.value = false
     attendanceResource.reload()
     createToast({
-      title: 'Leave Applied Successful',
+      title: 'Leave applied successfully',
       icon: 'check',
       iconClasses: 'text-green-600',
     })

--- a/frontend/src/pages/Attendance.vue
+++ b/frontend/src/pages/Attendance.vue
@@ -153,7 +153,7 @@ const applyLeave = createResource({
     isAttendancePage.value = false
     attendanceResource.reload()
     createToast({
-      title: 'Attendance Applied Successful',
+      title: 'Leave Applied Successful',
       icon: 'check',
       iconClasses: 'text-green-600',
     })

--- a/frontend/src/pages/Fees.vue
+++ b/frontend/src/pages/Fees.vue
@@ -171,7 +171,7 @@ const openModal = (row) => {
 const success = () => {
   feesResource.reload()
   createToast({
-    title: 'Payment Successful',
+    title: 'Payment successful',
     icon: 'check',
     iconClasses: 'text-green-600',
   })


### PR DESCRIPTION
From Student-portal when applying leave the success message is showing "Attendance Applied Succesful" instead of "Leave Applied Successful" 


BEFORE
![image](https://github.com/user-attachments/assets/e62292eb-bea2-4860-a026-9f97bae3524d)

AFTER
![image](https://github.com/user-attachments/assets/3bb86398-b787-4a4c-8ecd-5ac9fc7237ff)
