### PR TITLE
fix: return currency if no symbol found

### DIFF
--- a/education/education/api.py
+++ b/education/education/api.py
@@ -706,7 +706,7 @@ def get_student_invoices(student):
 
 
 def get_currency_symbol(currency):
-	return frappe.db.get_value("Currency", currency, "symbol")
+	return frappe.db.get_value("Currency", currency, "symbol") or currency
 
 
 def get_posting_date_from_payment_entry_against_sales_invoice(sales_invoice):


### PR DESCRIPTION
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/b12164c5-13bf-4d30-96d2-441a8505a929">

if no symbol was found then invoices were not being displayed in student invoices.