### PR TITLE
feat: Announcement page to display announcements from newsletters on student portal

### DIFF
--- a/education/education/api.py
+++ b/education/education/api.py
@@ -761,16 +761,18 @@ def get_student_attendance(student, student_group):
 		fields=["date", "status", "name"],
 	)
 
+
 @frappe.whitelist()
 def get_announcements():
     announcements = frappe.get_all(
         "Newsletter",
         filters={"published": 1},
-        fields=["subject", "creation","message"]
+        fields=["subject", "creation", "message"]
     )
 
     for announcement in announcements:
         if "creation" in announcement:
-            announcement["creation"] = datetime.strftime(announcement["creation"], "%m-%d-%Y")
+            announcement["creation"] = frappe.utils.pretty_date(announcement["creation"])
 
     return announcements
+

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -771,6 +771,6 @@ def get_announcements():
 
     for announcement in announcements:
         if "creation" in announcement:
-            announcement["creation"] = datetime.strftime(announcement["creation"], "%d-%m-%Y")
+            announcement["creation"] = datetime.strftime(announcement["creation"], "%m-%d-%Y")
 
     return announcements

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -10,6 +10,7 @@ from frappe.email.doctype.email_group.email_group import add_subscribers
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import cstr, flt, getdate
 from frappe.utils.dateutils import get_dates_from_timegrain
+from datetime import datetime
 
 
 def get_course(program):
@@ -762,7 +763,14 @@ def get_student_attendance(student, student_group):
 
 @frappe.whitelist()
 def get_announcements():
-    announcements = frappe.get_all("Newsletter", 
-                                   filters={"published": 1}, 
-                                   fields=["subject", "content", "creation as announcement_date"])
+    announcements = frappe.get_all(
+        "Newsletter",
+        filters={"published": 1},
+        fields=["subject", "creation","message"]
+    )
+
+    for announcement in announcements:
+        if "creation" in announcement:
+            announcement["creation"] = datetime.strftime(announcement["creation"], "%d-%m-%Y")
+
     return announcements

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -759,3 +759,10 @@ def get_student_attendance(student, student_group):
 		filters={"student": student, "student_group": student_group, "docstatus": 1},
 		fields=["date", "status", "name"],
 	)
+
+@frappe.whitelist()
+def get_announcements():
+    announcements = frappe.get_all("Newsletter", 
+                                   filters={"published": 1}, 
+                                   fields=["subject", "content", "creation as announcement_date"])
+    return announcements

--- a/education/education/doctype/school_announcement/school_announcement.js
+++ b/education/education/doctype/school_announcement/school_announcement.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("School Announcement", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/education/education/doctype/school_announcement/school_announcement.json
+++ b/education/education/doctype/school_announcement/school_announcement.json
@@ -1,0 +1,90 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:ANC-{MM}-{#####}",
+ "creation": "2025-02-26 16:22:04.198050",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "column_break_ywyl",
+  "posting_date",
+  "descriptions_section",
+  "description",
+  "section_break_uyky",
+  "announcement_date",
+  "column_break_uhyk",
+  "is_published"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title"
+  },
+  {
+   "fieldname": "column_break_ywyl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Today",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_published",
+   "fieldtype": "Check",
+   "label": "Is Published?"
+  },
+  {
+   "fieldname": "descriptions_section",
+   "fieldtype": "Section Break",
+   "label": "Descriptions"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "label": "Description"
+  },
+  {
+   "fieldname": "section_break_uyky",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "announcement_date",
+   "fieldtype": "Date",
+   "label": "Announcement Date"
+  },
+  {
+   "fieldname": "column_break_uhyk",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-02-26 16:33:07.237999",
+ "modified_by": "Administrator",
+ "module": "Education",
+ "name": "School Announcement",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/education/education/doctype/school_announcement/school_announcement.py
+++ b/education/education/doctype/school_announcement/school_announcement.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class SchoolAnnouncement(Document):
+	pass

--- a/education/education/doctype/school_announcement/test_school_announcement.py
+++ b/education/education/doctype/school_announcement/test_school_announcement.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSchoolAnnouncement(FrappeTestCase):
+	pass

--- a/education/public/frontend/index.html
+++ b/education/public/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/assets/education/frontend/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Frappe Education</title>
-    <script type="module" crossorigin src="/assets/education/frontend/assets/index.5fb23331.js"></script>
+    <script type="module" crossorigin src="/assets/education/frontend/assets/index.a58cfeb7.js"></script>
     <link rel="modulepreload" href="/assets/education/frontend/assets/frappe-ui.cf491ab7.js">
     <link rel="stylesheet" href="/assets/education/frontend/assets/frappe-ui.005832b0.css">
     <link rel="stylesheet" href="/assets/education/frontend/assets/index.570170c2.css">
@@ -26,6 +26,6 @@
       }
       link.href = '{{ logo }}'
     </script>
-
+    
   </body>
 </html>

--- a/education/public/frontend/index.html
+++ b/education/public/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/assets/education/frontend/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Frappe Education</title>
-    <script type="module" crossorigin src="/assets/education/frontend/assets/index.0b3bc70d.js"></script>
+    <script type="module" crossorigin src="/assets/education/frontend/assets/index.f6f5f244.js"></script>
     <link rel="modulepreload" href="/assets/education/frontend/assets/frappe-ui.cf491ab7.js">
     <link rel="stylesheet" href="/assets/education/frontend/assets/frappe-ui.005832b0.css">
     <link rel="stylesheet" href="/assets/education/frontend/assets/index.b142f333.css">

--- a/education/public/frontend/index.html
+++ b/education/public/frontend/index.html
@@ -5,10 +5,10 @@
     <link rel="icon" href="/assets/education/frontend/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Frappe Education</title>
-    <script type="module" crossorigin src="/assets/education/frontend/assets/index.a58cfeb7.js"></script>
+    <script type="module" crossorigin src="/assets/education/frontend/assets/index.0b3bc70d.js"></script>
     <link rel="modulepreload" href="/assets/education/frontend/assets/frappe-ui.cf491ab7.js">
     <link rel="stylesheet" href="/assets/education/frontend/assets/frappe-ui.005832b0.css">
-    <link rel="stylesheet" href="/assets/education/frontend/assets/index.570170c2.css">
+    <link rel="stylesheet" href="/assets/education/frontend/assets/index.b142f333.css">
   </head>
   <body>
     <div id="app"></div>

--- a/education/public/node_modules
+++ b/education/public/node_modules
@@ -1,1 +1,1 @@
-/Users/ritviksardana/version-15/apps/education/node_modules
+/home/techmaniacc/Documents/frappe-bench/apps/education/node_modules

--- a/education/public/node_modules
+++ b/education/public/node_modules
@@ -1,1 +1,1 @@
-/home/techmaniacc/Documents/frappe-bench/apps/education/node_modules
+/Users/techmaniacc/Code/Bench/frappe-bench/apps/education/node_modules

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -82,6 +82,12 @@ const links = [
     to: '/attendance',
     icon: UserCheck,
   },
+  {
+    label: 'Announcement',
+    to: '/announcements',
+    icon: UserCheck,
+  },
+  
   // {
   // 	// TODO: create School Diary Page with card like CRM and from ListView go to Resource Document of each Card
   // 	label: 'Notes',

--- a/frontend/src/pages/Announcement.vue
+++ b/frontend/src/pages/Announcement.vue
@@ -1,0 +1,66 @@
+<template>
+    <div class="p-6">
+      <h2 class="text-2xl font-bold mb-4">Announcements & Newsletters</h2>
+      <div v-if="announcements.length" class="space-y-4">
+        <div
+          v-for="announcement in announcements"
+          :key="announcement.name"
+          class="p-4 bg-white shadow-md rounded-lg"
+        >
+          <h3 class="text-xl font-semibold">{{ announcement.subject }}</h3>
+          <p class="text-gray-600 mt-2">{{ announcement.content }}</p>
+          <button
+            class="mt-3 text-blue-600 hover:underline"
+            @click="openAnnouncement(announcement)"
+          >
+            Read More
+          </button>
+        </div>
+      </div>
+      <div v-else class="text-gray-500">No announcements available.</div>
+  
+      <Dialog v-model="showDialog" :options="{ size: 'xl', title: selectedAnnouncement.subject }">
+        <template #body-content>
+          <p class="text-gray-700" v-html="selectedAnnouncement.content"></p>
+        </template>
+      </Dialog>
+    </div>
+  </template>
+  
+  <script setup>
+  import { ref, onMounted } from 'vue'
+  import { Dialog, createResource } from 'frappe-ui'
+  
+  const announcements = ref([])
+  const showDialog = ref(false)
+  const selectedAnnouncement = ref({})
+  
+  const fetchAnnouncements = createResource({
+    url: 'education.education.api.get_announcements',
+    onSuccess: (data) => {
+      announcements.value = data.map(announcement => ({
+        ...announcement,
+        summary: truncateDescription(announcement.content),
+      }))
+    },
+    onError: (err) => {
+      console.error('Error fetching announcements:', err)
+    }
+  })
+  
+  onMounted(() => {
+    fetchAnnouncements.reload()
+  })
+  
+  const openAnnouncement = (announcement) => {
+    selectedAnnouncement.value = announcement
+    showDialog.value = true
+  }
+  
+  const truncateDescription = (description) => {
+    const maxLength = 100
+    return description.length > maxLength
+      ? description.substring(0, maxLength) + '...'
+      : description
+  }
+  </script>

--- a/frontend/src/pages/Announcement.vue
+++ b/frontend/src/pages/Announcement.vue
@@ -1,66 +1,73 @@
 <template>
-    <div class="p-6">
-      <h2 class="text-2xl font-bold mb-4">Announcements & Newsletters</h2>
-      <div v-if="announcements.length" class="space-y-4">
-        <div
-          v-for="announcement in announcements"
-          :key="announcement.name"
-          class="p-4 bg-white shadow-md rounded-lg"
-        >
-          <h3 class="text-xl font-semibold">{{ announcement.subject }}</h3>
-          <p class="text-gray-600 mt-2">{{ announcement.content }}</p>
-          <button
-            class="mt-3 text-blue-600 hover:underline"
-            @click="openAnnouncement(announcement)"
-          >
-            Read More
-          </button>
-        </div>
+  <div class="p-6 relative">
+    <h2 class="text-2xl font-bold mb-4">Announcements & Newsletters</h2>
+
+    <div
+      v-if="announcements.length"
+      class="grid grid-cols-1 sm:grid-cols-2 gap-6"
+      :class="{ 'opacity-30 pointer-events-none': showDialog }"
+    >
+      <div
+        v-for="announcement in announcements"
+        :key="announcement.subject"
+        class="p-4 bg-white shadow-md rounded-lg cursor-pointer hover:bg-gray-100 transition"
+        @click="openAnnouncement(announcement)"
+      >
+        <h3 class="text-xl font-semibold">{{ announcement.subject }}</h3>
+        <p class="text-gray-600 mt-1">📅 {{ announcement.creation }}</p>
       </div>
-      <div v-else class="text-gray-500">No announcements available.</div>
-  
-      <Dialog v-model="showDialog" :options="{ size: 'xl', title: selectedAnnouncement.subject }">
-        <template #body-content>
-          <p class="text-gray-700" v-html="selectedAnnouncement.content"></p>
-        </template>
-      </Dialog>
     </div>
-  </template>
-  
-  <script setup>
-  import { ref, onMounted } from 'vue'
-  import { Dialog, createResource } from 'frappe-ui'
-  
-  const announcements = ref([])
-  const showDialog = ref(false)
-  const selectedAnnouncement = ref({})
-  
-  const fetchAnnouncements = createResource({
-    url: 'education.education.api.get_announcements',
-    onSuccess: (data) => {
-      announcements.value = data.map(announcement => ({
-        ...announcement,
-        summary: truncateDescription(announcement.content),
-      }))
-    },
-    onError: (err) => {
-      console.error('Error fetching announcements:', err)
-    }
-  })
-  
-  onMounted(() => {
-    fetchAnnouncements.reload()
-  })
-  
-  const openAnnouncement = (announcement) => {
-    selectedAnnouncement.value = announcement
-    showDialog.value = true
+
+    <div v-else class="text-gray-500">No announcements available.</div>
+
+    <div
+      v-if="showDialog"
+      class="fixed inset-0 bg-black bg-opacity-50 z-40"
+      @click="showDialog = false"
+    ></div>
+
+    <div
+      v-if="showDialog"
+      class="fixed inset-0 flex items-center justify-center z-50"
+    >
+      <div class="bg-white w-11/12 md:w-3/4 lg:w-2/3 xl:w-1/2 p-6 rounded-lg shadow-lg">
+        <h2 class="text-2xl font-bold mb-4">{{ selectedAnnouncement.subject }}</h2>
+        <div class="ql-editor read-mode" v-html="selectedAnnouncement.message"></div>
+        <button
+          class="mt-4 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition"
+          @click="showDialog = false"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { createResource } from 'frappe-ui'
+
+const announcements = ref([])
+const showDialog = ref(false)
+const selectedAnnouncement = ref({})
+
+const fetchAnnouncements = createResource({
+  url: 'education.education.api.get_announcements',
+  onSuccess: (data) => {
+    announcements.value = data
+  },
+  onError: (err) => {
+    console.error('Error fetching announcements:', err)
   }
-  
-  const truncateDescription = (description) => {
-    const maxLength = 100
-    return description.length > maxLength
-      ? description.substring(0, maxLength) + '...'
-      : description
-  }
-  </script>
+})
+
+onMounted(() => {
+  fetchAnnouncements.reload()
+})
+
+const openAnnouncement = (announcement) => {
+  selectedAnnouncement.value = announcement
+  showDialog.value = true
+}
+</script>

--- a/frontend/src/pages/Announcement.vue
+++ b/frontend/src/pages/Announcement.vue
@@ -29,7 +29,7 @@
               <span class="font-normal">{{ item }}</span>
             </template>
             <template v-else-if="column.key === 'creation'">
-              <span class="text-gray-600">📅 {{ formatDate(item) }}</span>
+              <span class="text-gray-600"> {{ item }}</span>
             </template>
           </ListRowItem>
         </ListRow>
@@ -96,10 +96,6 @@ const fetchAnnouncements = createResource({
   },
   auto: true,
 })
-
-const formatDate = (dateString) => {
-  return new Date(dateString).toLocaleDateString()
-}
 
 const openAnnouncement = (announcement) => {
   selectedAnnouncement.value = announcement

--- a/frontend/src/pages/Announcement.vue
+++ b/frontend/src/pages/Announcement.vue
@@ -1,70 +1,105 @@
 <template>
-  <div class="p-6 relative">
-    <h2 class="text-2xl font-bold mb-4">Announcements & Newsletters</h2>
-
-    <div
-      v-if="announcements.length"
-      class="grid grid-cols-1 sm:grid-cols-2 gap-6"
-      :class="{ 'opacity-30 pointer-events-none': showDialog }"
-    >
-      <div
-        v-for="announcement in announcements"
-        :key="announcement.subject"
-        class="p-4 bg-white shadow-md rounded-lg cursor-pointer hover:bg-gray-100 transition"
-        @click="openAnnouncement(announcement)"
+  <div class="">
+    <div v-if="tableData.rows.length > 0" class="px-5 py-4">
+      <ListView
+        :columns="tableData.columns"
+        :rows="tableData.rows"
+        :options="{
+          selectable: false,
+          showTooltip: false,
+          onRowClick: (row) => openAnnouncement(row),
+        }"
+        row-key="name"
       >
-        <h3 class="text-xl font-semibold">{{ announcement.subject }}</h3>
-        <p class="text-gray-600 mt-1">📅 {{ announcement.creation }}</p>
-      </div>
-    </div>
-
-    <div v-else class="text-gray-500">No announcements available.</div>
-
-    <div
-      v-if="showDialog"
-      class="fixed inset-0 bg-black bg-opacity-50 z-40"
-      @click="showDialog = false"
-    ></div>
-
-    <div
-      v-if="showDialog"
-      class="fixed inset-0 flex items-center justify-center z-50"
-    >
-      <div class="bg-white w-11/12 md:w-3/4 lg:w-2/3 xl:w-1/2 p-6 rounded-lg shadow-lg">
-        <h2 class="text-2xl font-bold mb-4">{{ selectedAnnouncement.subject }}</h2>
-        <div class="ql-editor read-mode" v-html="selectedAnnouncement.message"></div>
-        <button
-          class="mt-4 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition"
-          @click="showDialog = false"
+        <ListHeader>
+          <ListHeaderItem
+            v-for="column in tableData.columns"
+            :key="column.key"
+            :item="column"
+          />
+        </ListHeader>
+        <ListRow
+          v-for="row in tableData.rows"
+          :key="row.name"
+          :row="row"
+          v-slot="{ column, item }"
         >
-          Close
-        </button>
-      </div>
+          <ListRowItem :item="item" :align="column.align">
+            <template v-if="column.key === 'subject'">
+              <span class="font-normal">{{ item }}</span>
+            </template>
+            <template v-else-if="column.key === 'creation'">
+              <span class="text-gray-600">📅 {{ formatDate(item) }}</span>
+            </template>
+          </ListRowItem>
+        </ListRow>
+      </ListView>
     </div>
+
+    <div v-else>
+      <MissingData message="No announcements available" />
+    </div>
+
+    <Dialog
+      v-model="showDialog"
+      :options="{
+        title: selectedAnnouncement.subject,
+        size: '2xl',
+      }"
+    >
+      <template #body-content>
+        <div class="ql-editor read-mode" v-html="selectedAnnouncement.message"></div>
+      </template>
+    </Dialog>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
-import { createResource } from 'frappe-ui'
+import { reactive, ref } from 'vue'
+import {
+  ListView,
+  ListHeader,
+  ListHeaderItem,
+  ListRow,
+  ListRowItem,
+  Dialog,
+  createResource,
+} from 'frappe-ui'
+import MissingData from '@/components/MissingData.vue'
 
-const announcements = ref([])
+const tableData = reactive({
+  rows: [],
+  columns: [
+    {
+      label: 'Subject',
+      key: 'subject',
+      width: 2,
+    },
+    {
+      label: 'Posting Date',
+      key: 'creation',
+      width: 1,
+    },
+  ],
+})
+
 const showDialog = ref(false)
 const selectedAnnouncement = ref({})
 
 const fetchAnnouncements = createResource({
   url: 'education.education.api.get_announcements',
   onSuccess: (data) => {
-    announcements.value = data
+    tableData.rows = data
   },
   onError: (err) => {
     console.error('Error fetching announcements:', err)
-  }
+  },
+  auto: true,
 })
 
-onMounted(() => {
-  fetchAnnouncements.reload()
-})
+const formatDate = (dateString) => {
+  return new Date(dateString).toLocaleDateString()
+}
 
 const openAnnouncement = (announcement) => {
   selectedAnnouncement.value = announcement

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -26,6 +26,11 @@ const routes = [
     component: () => import('@/pages/Attendance.vue'),
   },
   {
+    path: '/announcements',
+    name: 'Announcements',
+    component: () => import('@/pages/Announcement.vue'),
+  },
+  {
     path: '/:catchAll(.*)',
     redirect: '/schedule',
   },

--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,5 +1,5 @@
 {
-  "systemParams": "darwin-arm64-108",
+  "systemParams": "linux-x64-120",
   "modulesFolders": [
     "node_modules"
   ],


### PR DESCRIPTION
User creates new newsletter from the Newsletter doctype. Then publish the announcement
![image](https://github.com/user-attachments/assets/62a7ee9f-9d00-409d-a820-9bed66acf70a)


Then on the students, click on the Announcement button on sidebar, it will display all announcements
![image](https://github.com/user-attachments/assets/df470023-77b8-485f-b38f-430c53916b45)

Then you can click on each announcement to see the message which will appear like a dialog box
![image](https://github.com/user-attachments/assets/2d29e4d8-df4f-4220-99a0-535f7f590c14)


