### PR TITLE
feat - Allow generation of report cards for all assesmnet group(remove filter is Group)

### DIFF
--- a/education/education/doctype/student_report_generation_tool/student_report_generation_tool.js
+++ b/education/education/doctype/student_report_generation_tool/student_report_generation_tool.js
@@ -10,13 +10,6 @@ frappe.ui.form.on('Student Report Generation Tool', {
         },
       }
     })
-    frm.set_query('assessment_group', function () {
-      return {
-        filters: {
-          is_group: 1,
-        },
-      }
-    })
   },
 
   refresh: function (frm) {


### PR DESCRIPTION
Before, user could not print assessment groups which are not group.
![Screenshot 2025-03-21 at 16 05 59](https://github.com/user-attachments/assets/e8650da1-92b8-47c5-976d-53fa14921e6d)


But there is a case for midterm when students need report for the exam they just did, before the term reach the end.
So we have to make room for that.
![Screenshot 2025-03-21 at 16 07 22](https://github.com/user-attachments/assets/151a8f89-94ad-4cf1-b49f-180a7b137a10)
I removed the filter of is_group==1.
