### PR TITLE
fix: use ignore_account_permission flag to create PE

### DIFF
--- a/education/education/billing.py
+++ b/education/education/billing.py
@@ -114,7 +114,8 @@ def handle_payment_success(response, against_invoice, billing_details):
 	)
 
 	try:
-		pe = get_payment_entry("Sales Invoice", against_invoice, ignore_permissions=True)
+		frappe.flags.ignore_account_permission = True
+		pe = get_payment_entry("Sales Invoice", against_invoice)
 		pe.reference_no = response["razorpay_order_id"]
 		pe.reference_date = nowdate()
 		pe.posting_date = nowdate()


### PR DESCRIPTION
Instead of passing `ignore_permissions` parameter while creating a Payment Entry, we can use `frappe.flags.ignore_account_permission` to do the same. 

This way we wont have `ignore_permissions`  on a `whitelisted` method

Securite Issue: https://github.com/frappe/security/issues/129

Related: https://github.com/frappe/erpnext/pull/47262

