### PR TITLE
fix(webform): remove non-existent company field from Student Applicant

### DIFF
--- a/education/education/web_form/student_applicant/student_applicant.json
+++ b/education/education/web_form/student_applicant/student_applicant.json
@@ -493,19 +493,6 @@
    "read_only": 1,
    "reqd": 0,
    "show_in_filter": 0
-  },
-  {
-   "allow_read_on_all_link_options": 0,
-   "fieldname": "company",
-   "fieldtype": "Link",
-   "hidden": 0,
-   "label": "Company",
-   "max_length": 0,
-   "max_value": 0,
-   "options": "Company",
-   "read_only": 0,
-   "reqd": 0,
-   "show_in_filter": 0
   }
  ]
 }


### PR DESCRIPTION
This PR removes the `company` field from the **Student Applicant** web form.

* The field was introduced in commit [[4f8667b](https://github.com/frappe/education/commit/4f8667b4ac1a07126d80c7929b331ad2e01b7ca5#diff-f75843f45947d4aab8a733f9b850b542aa4496492e2868c175c81ed8675b671b)] , but it does **not exist** in the underlying **Student Applicant DocType**.
* As a result, editing or saving the web form currently throws an error:

  ```
  Following fields are missing: Company
  ```
* This patch aligns the web form with the current DocType and resolves the error reported by users.

If the maintainers feel that **Student Applicant should indeed have a `company` field**, please let me know — I’ll be happy to add it to the DocType in a follow-up PR instead of removing it here.

**Steps to Reproduce the Bug:**

1. Go to **Website > Web Forms > Student Applicant**.
2. Try editing or saving the web form.
3. Observe error: *“Following fields are missing: Company”*.

**Fix:**
Removed the non-existent `company` field from `student_applicant.json` web form definition.

`no-docs`