### PR TITLE
feat(education/fee_category): Enforce validation for mandatory accoun…

### DIFF
--- a/education/education/doctype/fee_category/fee_category.py
+++ b/education/education/doctype/fee_category/fee_category.py
@@ -10,6 +10,7 @@ class FeeCategory(Document):
 	def validate(self):
 		self.update_defaults_from_item_group()
 		self.validate_duplicate_item_defaults()
+		self.validate_all_companies_covered()
 
 	def after_insert(self):
 		# create an item
@@ -52,6 +53,30 @@ class FeeCategory(Document):
 		if len(companies) != len(set(companies)):
 			frappe.throw(_("Cannot set multiple Item Defaults for a company."))
 
+	def validate_all_companies_covered(self):
+		"""Validate that Item Defaults are set for all active, mandatory companies."""
+
+		# 1. Get all active companies (not group companies)
+		active_companies = frappe.db.get_list("Company", filters={"is_group": 0}, pluck="name")
+
+		# 2. Get companies covered in the Fee Category's Item Defaults table
+		covered_companies = [d.company for d in self.item_defaults]
+
+		# If the defaults table is empty, skip the check (defaults will be fetched from Item Group later)
+		if not self.item_defaults:
+			return
+
+		# Find missing companies
+		missing_companies = list(set(active_companies) - set(covered_companies))
+
+		if missing_companies:
+			frappe.throw(
+				_("Please set Accounting Defaults for the following active companies: {0}").format(
+					", ".join(missing_companies)
+				),
+				title=_("Missing Company Defaults")
+			)
+
 
 def create_item(doc, use_name_field=True):
 	name_field = doc.name if use_name_field else doc.fees_category
@@ -82,6 +107,7 @@ def update_item(fee_category):
 	)
 	item_default_companies = [d.company for d in item_defaults]
 	fee_category_companies = [d.company for d in fee_category.item_defaults]
+
 	for fee_category_default in fee_category.item_defaults:
 		if fee_category_default.company not in item_default_companies:
 			add_item_defaults(item, fee_category_default)

--- a/education/education/doctype/fee_category/test_fee_category.py
+++ b/education/education/doctype/fee_category/test_fee_category.py
@@ -111,3 +111,37 @@ class TestFeeCategory(FrappeTestCase):
 		for default in default_array:
 			fee_component.append("item_defaults", default)
 		self.assertRaises(frappe.ValidationError, fee_component.save)
+
+	def test_missing_company_default(self):
+		"""
+		Validation must fail if Fee Category Defaults are missing for an active company.
+		"""
+		# Create a second company for the test environment
+		create_company("Missing Test Co")
+
+		fee_category_name = "Test Fee Category Missing Company"
+		fee_category = create_fee_category(fee_category_name)
+		defaults = get_defaults()
+
+		# Set default for ONLY the primary company (_Test Company)
+		fee_category.append(
+			"item_defaults",
+			{
+				"company": "_Test Company",
+				"income_account": defaults.default_income_account,
+				"selling_cost_center": defaults.cost_center,
+			},
+		)
+
+		# Expect an error since "Missing Test Co" is not covered
+		with self.assertRaises(frappe.exceptions.ValidationError) as cm:
+			fee_category.save()
+
+		# Assert the error message is correct
+		self.assertIn(
+			"Please set Accounting Defaults for the following active companies",
+			str(cm.exception),
+		)
+
+		# Clean up the created company
+		frappe.delete_doc("Company", "Missing Test Co")


### PR DESCRIPTION
This PR introduces a crucial validation to the Fee Category Doctype to ensure accounting defaults are defined for all active, non-group companies in a multi-company environment. This prevents fatal errors in downstream financial transactions.

What has been changed?
**Validation Added**: A new method, validate_all_companies_covered, is added to the FeeCategory class in fee_category.py.

**Validation Trigger**: This method is called during the validate hook, checking if every active company in the system has a corresponding entry in the item_defaults (Accounting Defaults) table.

**New Test Case**: A new unit test, test_missing_company_default, has been added to test_fee_category.py to confirm the validation throws a ValidationError when a company's defaults are missing.

**Why is this necessary?** (Problem Solved)
In a multi-company setup, if a user creates a Fees Invoice for a company whose accounting defaults were not set in the Fee Category, the system will crash because it cannot find the mandatory Income Account and Selling Cost Center for that specific entity. This change forces the user to complete the setup at the master data level, guaranteeing that fee transactions will not fail later due to missing configuration.

<img width="1494" height="758" alt="frappe1" src="https://github.com/user-attachments/assets/dcfef60d-5bd8-42ca-a6a3-a8d7035ed187" />
