### PR TITLE
feat(docker): Add Docker setup for Education Frappe

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,29 @@ The script will set up a production-ready instance of Frappe Education with all 
 1. Now open the URL `http://education.test:8000/education` in your browser, you should see the app running
 1. To access student portal, open the URL `http://education.test:8000/student-portal` in your browser, you should see the student portal running.
 
+### Docker
+
+You need Docker, docker-compose and git setup on your machine. Refer [Docker documentation](https://docs.docker.com/). After that, follow below steps:
+
+**Step 1**: Setup folder and download the required files
+
+    mkdir frappe-education
+    cd frappe-education
+
+    # Download the docker-compose file
+    wget -O docker-compose.yml https://raw.githubusercontent.com/frappe/education/develop/docker/docker-compose.yml
+
+    # Download the setup script
+    wget -O init.sh https://raw.githubusercontent.com/frappe/education/develop/docker/init.sh
+
+**Step 2**: Run the container and daemonize it
+
+    docker compose up -d
+
+**Step 3**: The site [http://education.localhost:8000/](http://education.localhost:8000) should now be available. The default credentials are:
+
+-   Username: Administrator
+-   Password: admin
 
 ## Learn and connect
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.7'
+name: education
+services:
+  mariadb:
+    image: mariadb:10.8
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
+    environment:
+      MYSQL_ROOT_PASSWORD: 123
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    networks:
+      - frappe-network
+
+  redis:
+    image: redis:alpine
+    networks:
+      - frappe-network
+
+  frappe:
+    image: frappe/bench:latest
+    command: bash /workspace/init.sh
+    environment:
+      - SHELL=/bin/bash
+    working_dir: /home/frappe
+    volumes:
+      - .:/workspace
+    ports:
+      - 8000:8000
+      - 9000:9000
+    networks:
+      - frappe-network
+
+volumes:
+  mariadb-data:
+
+networks:
+  frappe-network:
+    driver: bridge

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,43 @@
+#!bin/bash
+
+if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
+    echo "Bench already exists, skipping init"
+    cd frappe-bench
+    bench start
+else
+    echo "Creating new bench..."
+fi
+
+export PATH="${NVM_DIR}/versions/node/v${NODE_VERSION_DEVELOP}/bin/:${PATH}"
+
+bench init --skip-redis-config-generation frappe-bench
+
+cd frappe-bench
+
+# Use containers instead of localhost
+bench set-mariadb-host mariadb
+bench set-redis-cache-host redis://redis:6379
+bench set-redis-queue-host redis://redis:6379
+bench set-redis-socketio-host redis://redis:6379
+
+# Remove redis, watch from Procfile
+sed -i '/redis/d' ./Procfile
+sed -i '/watch/d' ./Procfile
+
+bench get-app erpnext
+bench get-app education
+
+bench new-site education.localhost \
+--force \
+--mariadb-root-password 123 \
+--admin-password admin \
+--no-mariadb-socket
+
+bench --site education.localhost install-app erpnext
+bench --site education.localhost install-app education
+bench --site education.localhost set-config developer_mode 1
+bench --site education.localhost enable-scheduler
+bench --site education.localhost clear-cache
+bench use education.localhost
+
+bench start


### PR DESCRIPTION
Issue:

Setting up the Frappe + Education module locally often requires multiple manual steps, including installing MariaDB, Redis, Node, wkhtmltopdf dependencies, configuring environment variables, setting up the bench & installing ERPNext + Education apps. This makes onboarding difficult and increases time-to-setup for new developers or testers.

Solution:

This PR introduces a complete Dockerized environment for Frappe with the Education module.
It includes:

1. A docker-compose.yml using MariaDB, Redis, and the official frappe/bench image.
2. Automated bench initialization via /docker/init.sh.
3. Auto-setup of a new site (education.localhost) with ERPNExt + Education apps pre-installed.
4. Ready-to-run development environment with developer mode enabled.

What Changed:

Added docker-compose.yml with:

- Frappe Bench container with port mapping
- Shared volumes and network setup
- MariaDB 10.8 & Redis configured

Added docker/init.sh to:

- Detect existing bench or create a new one
- Install ERPNext and Education apps
- Create new site education.localhost
- Enable developer mode and scheduler
- Start the bench automatically

Automated environment ensures:

- Zero manual setup
- Consistent reproducible local environment
- Simplified development workflow for Education module contributors

Result:

Developers can now spin up the entire Frappe + Education stack using:

_docker-compose up --build_

This reduces setup time drastically and ensures a stable, containerized development environment.


https://github.com/user-attachments/assets/6dada25b-f652-4ded-93da-c9ffabf65e28

