### PR TITLE
Refactor course query logic in program enrollment

### DIFF
--- a/education/education/doctype/fees/fees.js
+++ b/education/education/doctype/fees/fees.js
@@ -136,7 +136,11 @@ frappe.ui.form.on("Fees", {
 				"dt": frm.doc.doctype,
 				"dn": frm.doc.name,
 				"party_type": "Student",
-				"payment_type": "Receive",
+				"party": frm.doc.student,
+				"party_name": frm.doc.student_name,
+				"party_account_currency": frm.doc.currency,
+				"recipient_id": frm.doc.contact_email,
+				"payment_type": "Receive"
 			},
 			callback: function(r) {
 				var doc = frappe.model.sync(r.message);

--- a/education/education/doctype/fees/fees.js
+++ b/education/education/doctype/fees/fees.js
@@ -117,6 +117,8 @@ frappe.ui.form.on("Fees", {
 					"dn": frm.doc.name,
 					"party_type": "Student",
 					"party": frm.doc.student,
+					"party_name": frm.doc.student_name,
+					"party_account_currency": frm.doc.currency,
 					"recipient_id": frm.doc.contact_email
 				},
 				callback: function(r) {
@@ -136,10 +138,6 @@ frappe.ui.form.on("Fees", {
 				"dt": frm.doc.doctype,
 				"dn": frm.doc.name,
 				"party_type": "Student",
-				"party": frm.doc.student,
-				"party_name": frm.doc.student_name,
-				"party_account_currency": frm.doc.currency,
-				"recipient_id": frm.doc.contact_email,
 				"payment_type": "Receive"
 			},
 			callback: function(r) {

--- a/education/education/doctype/program_enrollment/program_enrollment.js
+++ b/education/education/doctype/program_enrollment/program_enrollment.js
@@ -83,6 +83,9 @@ frappe.ui.form.on('Program Enrollment', {
 				if (r.message) {
 					frm.program_courses = r.message
 					frm.set_value('courses', r.message);
+					(frm.doc.courses || []).forEach(row => {
+						frappe.model.trigger('course', row.doctype, row.name);
+					});					
 				}
 			}
 		})

--- a/education/education/doctype/program_enrollment/program_enrollment.js
+++ b/education/education/doctype/program_enrollment/program_enrollment.js
@@ -98,7 +98,7 @@ frappe.ui.form.on('Program Enrollment Course', {
 				if (val.course) course_list.push(val.course);
 			});
 			return { filters: [['Course', 'name', 'not in', course_list],
-				['Course', 'name', 'in', frm.program_courses.map((e) => e.course)]] };
+				['Course', 'name', 'in', frm.courses.map((e) => e.course)]] };
 		};
 	}
 });

--- a/education/education/doctype/program_enrollment/program_enrollment.js
+++ b/education/education/doctype/program_enrollment/program_enrollment.js
@@ -93,11 +93,18 @@ frappe.ui.form.on('Program Enrollment Course', {
 	courses_add: function(frm){
 		frm.fields_dict['courses'].grid.get_field('course').get_query = function(doc) {
 			var course_list = [];
-			if(!doc.__islocal) course_list.push(doc.name);
-			$.each(doc.courses || [], function(_idx, val) {
-				if (val.course) course_list.push(val.course);
-			});
+
+			$.each(frm.doc.courses || [], function(_idx, val) {
+				if (val.course) {
+					course_list.push(val.course);
+				}
+			});			
+
 			let program_courses = (frm.program_courses || []).map(e => e.course);
+
+			if (!program_courses.length) {
+				return { filters: [['Course', 'name', '=', '__none__']] };
+			}			
 			return { filters: [['Course', 'name', 'not in', course_list],
 				['Course', 'name', 'in', program_courses]] };
 		};

--- a/education/education/doctype/program_enrollment/program_enrollment.js
+++ b/education/education/doctype/program_enrollment/program_enrollment.js
@@ -94,11 +94,12 @@ frappe.ui.form.on('Program Enrollment Course', {
 		frm.fields_dict['courses'].grid.get_field('course').get_query = function(doc) {
 			var course_list = [];
 			if(!doc.__islocal) course_list.push(doc.name);
-			$.each(doc.courses, function(_idx, val) {
+			$.each(doc.courses || [], function(_idx, val) {
 				if (val.course) course_list.push(val.course);
 			});
+			let program_courses = (frm.program_courses || []).map(e => e.course);
 			return { filters: [['Course', 'name', 'not in', course_list],
-				['Course', 'name', 'in', frm.courses.map((e) => e.course)]] };
+				['Course', 'name', 'in', program_courses]] };
 		};
 	}
 });


### PR DESCRIPTION
### Problem
The course query logic in Program Enrollment could execute before the
program courses data was available, leading to undefined values and
incorrect filtering when adding courses in the child table. Also, the Courses
table did not auto populate when "Program" was selected.

### Solution
Refactored the client-side query logic in `program_enrollment.js` to ensure
that course data is properly scoped and available when the child table
trigger fires.

The change was tested on a Frappe Cloud instance running version-15 from
my fork.

### Result
- Correct course filtering during Program Enrollment
- Eliminates race/scope-related `undefined` errors
- No functional regression observed
-  Courses table now auto populates

Closes #381