### PR TITLE
Add pyproject.toml to education module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "education"
+authors = [
+    { name = "Frappe Technologies Pvt Ltd", email = "hello@frappe.io" }
+]
+description = "Education module for Frappe"
+readme = "README.md"
+requires-python = ">=3.10"
+dynamic = ["version"]
+
+[build-system]
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
+
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0-dev,<=17.0.0-dev"


### PR DESCRIPTION
Frappe Cloud now requires pyproject.toml for app validation. Education currently does not include this file, which prevents deployment. This PR adds a minimal pyproject.toml, following the structure used in frappe/helpdesk.