### PR TITLE
fix: Modify SQL query to include course_name in get_courses

### DIFF
--- a/education/education/doctype/program_enrollment/program_enrollment.js
+++ b/education/education/doctype/program_enrollment/program_enrollment.js
@@ -27,17 +27,6 @@ frappe.ui.form.on('Program Enrollment', {
         }
       }
 
-    if (frm.doc.program) {
-      frm.set_query('course', 'courses', function () {
-        return {
-          query:
-            'education.education.doctype.program_enrollment.program_enrollment.get_program_courses',
-          filters: {
-            program: frm.doc.program,
-          },
-        }
-      })
-    }
 
     // frm.set_query('student', function() {
     // 	return{

--- a/education/education/doctype/program_enrollment/program_enrollment.py
+++ b/education/education/doctype/program_enrollment/program_enrollment.py
@@ -88,7 +88,7 @@ class ProgramEnrollment(Document):
 	@frappe.whitelist()
 	def get_courses(self):
 		return frappe.db.sql(
-			"""select course from `tabProgram Course` where parent = %s and required = 1""",
+			"""select course,course_name from `tabProgram Course` where parent = %s and required = 1""",
 			(self.program),
 			as_dict=1,
 		)


### PR DESCRIPTION
Problem

When Program Enrollment is created from 'Student Applicant', the course is fetched into the
courses table but not the course_name.

Solution
The SQL did not have course_name in the SELECT.
Add course_name to the SQL SELECT.

Result
Correct population of course_name fields in courses table
No functional regression observed

Closes https://github.com/frappe/education/issues/387