### PR TITLE
 Fix: academic_term not copied from Student Applicant during enrollment

### DIFF
--- a/education/education/api.py
+++ b/education/education/api.py
@@ -51,7 +51,7 @@ def enroll_student(source_name):
 	student_applicant = frappe.db.get_value(
 		"Student Applicant",
 		source_name,
-		["student_category", "program", "academic_year"],
+		["student_category", "program", "academic_year", "academic_term"],
 		as_dict=True,
 	)
 	program_enrollment = frappe.new_doc("Program Enrollment")
@@ -60,6 +60,7 @@ def enroll_student(source_name):
 	program_enrollment.student_name = student.student_name
 	program_enrollment.program = student_applicant.program
 	program_enrollment.academic_year = student_applicant.academic_year
+	program_enrollment.academic_term = student_applicant.academic_term
 	program_enrollment.save()
 
 	frappe.publish_realtime(


### PR DESCRIPTION
Problem:
When Program Enrollment is created from Student Applicant during the "Enroll" process,
the academic_term field is not transferred to Program Enrollment

Solution
add two lines to ../education/api.py to include the field 'academic_term'
This mirrors how academic_year is already handled and keeps Student Applicant → Program Enrollment field mapping consistent.

This was tested on a Frappe Cloud server

Closes https://github.com/frappe/education/issues/389