### PR TITLE
chore(deps): bump Frappe dependency range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,4 @@ indent-style = "tab"
 docstring-code-format = true
 
 [tool.bench.frappe-dependencies]
-frappe = ">=16.0.0,<17.0.0"
+frappe = ">=17.0.0-dev,<18.0.0"


### PR DESCRIPTION
Update `tool.bench.frappe-dependencies.frappe` in `pyproject.toml` from `>=16.0.0,<17.0.0` to `>=17.0.0-dev,<18.0.0`.