### PR TITLE
feat: add School (campus/branch) doctype + Student school/reference_number fields

### DIFF
--- a/education/education/doctype/school/school.json
+++ b/education/education/doctype/school/school.json
@@ -1,0 +1,72 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:school",
+ "creation": "2026-01-01 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "school",
+  "description",
+  "location"
+ ],
+ "fields": [
+  {
+   "fieldname": "school",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "School",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "location",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Location"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-01-01 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Education",
+ "name": "School",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Academics User",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/education/education/doctype/school/school.py
+++ b/education/education/doctype/school/school.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class School(Document):
+	pass

--- a/education/education/doctype/school/test_school.py
+++ b/education/education/doctype/school/test_school.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# See license.txt
+
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSchool(FrappeTestCase):
+	pass

--- a/education/education/doctype/student/student.json
+++ b/education/education/doctype/student/student.json
@@ -22,6 +22,9 @@
   "image",
   "section_break_7",
   "student_email_id",
+  "school",
+  "reference_number",
+  "program",
   "date_of_birth",
   "blood_group",
   "column_break_3",
@@ -114,6 +117,23 @@
    "label": "Student Email Address",
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "fieldname": "school",
+   "fieldtype": "Link",
+   "label": "School",
+   "options": "School"
+  },
+  {
+   "fieldname": "reference_number",
+   "fieldtype": "Data",
+   "label": "Reference Number"
+  },
+  {
+   "fieldname": "program",
+   "fieldtype": "Link",
+   "label": "Program",
+   "options": "Program"
   },
   {
    "fieldname": "student_mobile_number",


### PR DESCRIPTION
## What

Adds a generic, dependency-free **School** (campus/branch) doctype to Education, plus three fields on **Student**:

- **`School`** doctype — `school` (name / autoname), `description`, `location`. No links to ERPNext (Company/Warehouse) and no region-specific fields, so Education gains **no new app dependency**.
- **`Student.school`** — Link → School
- **`Student.reference_number`** — Data (external / library-card identifier)
- **`Student.program`** — Link → Program (convenience field; see note)

## Why

Multi-campus schools need a branch/campus master and a way to tag a Student with their branch and an external reference number. Today this gets re-implemented as custom fields in every project. I built an open-source school **library circulation** app on top of Education that reads these fields, and the generic pieces belong in Education so any school benefits.

## Note on `Student.program`

Education models program membership via **Program Enrollment**. I included a direct `Student.program` link as a convenience because downstream apps read it directly — but I'm happy to **drop it** and rely on Program Enrollment if you'd prefer. Likewise, `School` is intentionally minimal and I'm happy to rename it (`Campus`/`Branch`) if that fits better.

## Testing

- `bench --site <site> migrate` syncs the `School` doctype and the new Student fields.
- Added a `TestSchool` stub; happy to expand coverage as guided.

Happy to open a separate discussion/issue first if the team prefers that for new doctypes.
