### PR TITLE
Introduce program-scoped student portal with leave application flow

### DIFF
--- a/education/education/api.py
+++ b/education/education/api.py
@@ -220,7 +220,7 @@ def get_student_group_students(student_group, include_inactive=0):
 
 	:param student_group: Student Group.
 	"""
-	if not frappe.has_permission("Student Group", "read"):
+	if not frappe.has_permission("Student Group", "read", student_group):
 		raise frappe.PermissionError(_("You are not authorized to access this student group"))
 
 	if include_inactive:

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -815,12 +815,12 @@ def apply_leave(leave_data, program_name):
 		"Education Settings", "attendance_based_on_course_schedule"
 	)
 	if attendance_based_on_course_schedule:
-		apply_leave_based_on_course_schedule(leave_data, program_name)
+		create_student_leave_application_based_on_course_schedule(leave_data, program_name)
 	else:
-		apply_leave_based_on_student_group(leave_data, program_name)
+		create_student_leave_application_based_on_student_group(leave_data, program_name)
 
 
-def apply_leave_based_on_course_schedule(leave_data, program_name):
+def create_student_leave_application_based_on_course_schedule(leave_data, program_name):
 	course_schedule_in_leave_period = frappe.db.get_list(
 		"Course Schedule",
 		fields=["name", "schedule_date"],
@@ -835,37 +835,32 @@ def apply_leave_based_on_course_schedule(leave_data, program_name):
 	)
 	if not course_schedule_in_leave_period:
 		frappe.throw(_("No classes found in the leave period"))
-	for course_schedule in course_schedule_in_leave_period:
-		# check if attendance record does not exist for the student on the course schedule
-		if not frappe.db.exists(
-			"Student Attendance",
-			{"course_schedule": course_schedule.get("name"), "docstatus": 1},
-		):
-			make_attendance_records(
-				leave_data.get("student"),
-				leave_data.get("student_name"),
-				"Leave",
-				course_schedule.get("name"),
-				None,
-				course_schedule.get("schedule_date"),
-			)
 
-
-def apply_leave_based_on_student_group(leave_data, program_name):
-	student_groups = get_student_groups(leave_data.get("student"), program_name)
-	leave_dates = get_dates_from_timegrain(
-		leave_data.get("from_date"), leave_data.get("to_date")
+	student_leave_application = frappe.new_doc("Student Leave Application")
+	student_leave_application.student = leave_data.get("student")
+	student_leave_application.student_name = leave_data.get("student_name")
+	student_leave_application.attendance_based_on = "Course Schedule"
+	student_leave_application.course_schedule = course_schedule_in_leave_period[0].get(
+		"name"
 	)
-	for student_group in student_groups:
-		for leave_date in leave_dates:
-			make_attendance_records(
-				leave_data.get("student"),
-				leave_data.get("student_name"),
-				"Leave",
-				None,
-				student_group.get("label"),
-				leave_date,
-			)
+	student_leave_application.from_date = leave_data.get("from_date")
+	student_leave_application.to_date = leave_data.get("to_date")
+	student_leave_application.reason = leave_data.get("reason")
+	student_leave_application.save()
+
+
+def create_student_leave_application_based_on_student_group(leave_data, program_name):
+	student_groups = get_student_groups(leave_data.get("student"), program_name)
+
+	student_leave_application = frappe.new_doc("Student Leave Application")
+	student_leave_application.student = leave_data.get("student")
+	student_leave_application.student_name = leave_data.get("student_name")
+	student_leave_application.attendance_based_on = "Student Group"
+	student_leave_application.student_group = student_groups[0].get("label")
+	student_leave_application.from_date = leave_data.get("from_date")
+	student_leave_application.to_date = leave_data.get("to_date")
+	student_leave_application.reason = leave_data.get("reason")
+	student_leave_application.save()
 
 
 @frappe.whitelist()

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -11,7 +11,6 @@ from frappe.model.mapper import get_mapped_doc
 from frappe.utils import cstr, flt, getdate, today
 from frappe.utils.dateutils import get_dates_from_timegrain
 
-
 PORTAL_STUDENT_FIELDS = [
 	"name",
 	"student_name",
@@ -221,7 +220,7 @@ def get_student_group_students(student_group, include_inactive=0):
 
 	:param student_group: Student Group.
 	"""
-	if not frappe.has_permission("Student Group", "read", student_group):
+	if not frappe.has_permission("Student Group", "read"):
 		raise frappe.PermissionError(_("You are not authorized to access this student group"))
 
 	if include_inactive:
@@ -631,7 +630,7 @@ def _get_program_enrollment(student, program):
 
 
 @frappe.whitelist()
-def get_portal_student_profile(student=None):
+def get_student_profile(student=None):
 	"""Portal bootstrap: student profile and all submitted program enrollments."""
 	student = _resolve_portal_student(student)
 	if not student:
@@ -654,7 +653,7 @@ def get_portal_student_profile(student=None):
 
 
 @frappe.whitelist()
-def get_portal_program_context(student=None, program=None):
+def get_program_context(student=None, program=None):
 	"""Portal context for the selected program: enrollment + student groups."""
 	student = _resolve_portal_student(student)
 	if not student:
@@ -674,45 +673,6 @@ def get_portal_program_context(student=None, program=None):
 		"enrollment": enrollment,
 		"student_groups": get_student_groups(student, program),
 	}
-
-
-@frappe.whitelist()
-def get_student_info():
-	email = frappe.session.user
-	if email == "Administrator":
-		return
-
-	student = frappe.db.get_value("Student", {"user": email}, "name")
-	if not student:
-		return None
-
-	return get_student_context(student)
-
-
-@frappe.whitelist()
-def get_student_context(student, program=None):
-	"""Returns portal context for a student (legacy shape).
-
-	Used where a single payload is expected. Prefer get_portal_student_profile
-	and get_portal_program_context for the portal SPA.
-
-	:param student: Student.
-	:param program: Optional Program to scope enrollment and student groups.
-	"""
-	profile = get_portal_student_profile(student)
-	if not profile:
-		return None
-
-	selected_program = program or profile.get("suggested_program")
-	student_info = profile["student"]
-	student_info["programs"] = profile["programs"]
-
-	if selected_program:
-		program_context = get_portal_program_context(student, selected_program)
-		student_info["current_program"] = program_context["enrollment"]
-		student_info["student_groups"] = program_context["student_groups"]
-
-	return student_info
 
 
 @frappe.whitelist()

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -12,6 +12,36 @@ from frappe.utils import cstr, flt, getdate, today
 from frappe.utils.dateutils import get_dates_from_timegrain
 
 
+PORTAL_STUDENT_FIELDS = [
+	"name",
+	"student_name",
+	"student_email_id",
+	"student_mobile_number",
+	"image",
+	"gender",
+	"blood_group",
+	"nationality",
+	"date_of_birth",
+	"joining_date",
+	"address_line_1",
+	"address_line_2",
+	"city",
+	"state",
+	"pincode",
+	"country",
+]
+
+PROGRAM_ENROLLMENT_FIELDS = [
+	"name as program_enrollment",
+	"program",
+	"student_name",
+	"student_batch_name as student_batch",
+	"student_category",
+	"academic_term",
+	"academic_year",
+]
+
+
 def get_course(program):
 	"""Return list of courses for a particular program
 	:param program: Program
@@ -557,6 +587,95 @@ def get_user_role():
 	return None
 
 
+def _resolve_portal_student(student=None):
+	if student:
+		return student
+
+	user = frappe.session.user
+	if user in ("Guest", "Administrator"):
+		return None
+
+	return frappe.db.get_value("Student", {"user": user}, "name")
+
+
+def _get_submitted_program_enrollments(student):
+	return frappe.db.get_list(
+		"Program Enrollment",
+		filters={"student": student, "docstatus": 1},
+		fields=PROGRAM_ENROLLMENT_FIELDS,
+		order_by="creation desc",
+	)
+
+
+def _resolve_default_program(student, programs):
+	if not programs:
+		return None
+
+	program_names = {row["program"] for row in programs}
+	active_enrollment = get_current_enrollment(student)
+	if active_enrollment and active_enrollment.get("program") in program_names:
+		return active_enrollment["program"]
+
+	return programs[0]["program"]
+
+
+def _get_program_enrollment(student, program):
+	enrollments = frappe.db.get_list(
+		"Program Enrollment",
+		filters={"student": student, "program": program, "docstatus": 1},
+		fields=PROGRAM_ENROLLMENT_FIELDS,
+		order_by="creation desc",
+		limit=1,
+	)
+	return enrollments[0] if enrollments else None
+
+
+@frappe.whitelist()
+def get_portal_student_profile(student=None):
+	"""Portal bootstrap: student profile and all submitted program enrollments."""
+	student = _resolve_portal_student(student)
+	if not student:
+		return None
+
+	check_permission(student, "profile")
+
+	student_info = frappe.db.get_value(
+		"Student", student, PORTAL_STUDENT_FIELDS, as_dict=True
+	)
+	if not student_info:
+		return None
+
+	programs = _get_submitted_program_enrollments(student)
+	return {
+		"student": student_info,
+		"programs": programs,
+		"suggested_program": _resolve_default_program(student, programs),
+	}
+
+
+@frappe.whitelist()
+def get_portal_program_context(student=None, program=None):
+	"""Portal context for the selected program: enrollment + student groups."""
+	student = _resolve_portal_student(student)
+	if not student:
+		return None
+
+	if not program:
+		frappe.throw(_("Program is required"))
+
+	check_permission(student, "profile")
+
+	enrollment = _get_program_enrollment(student, program)
+	if not enrollment:
+		frappe.throw(_("Program enrollment not found"))
+
+	return {
+		"program": program,
+		"enrollment": enrollment,
+		"student_groups": get_student_groups(student, program),
+	}
+
+
 @frappe.whitelist()
 def get_student_info():
 	email = frappe.session.user
@@ -571,26 +690,28 @@ def get_student_info():
 
 
 @frappe.whitelist()
-def get_student_context(student):
-	"""Returns the full portal context for a single student.
+def get_student_context(student, program=None):
+	"""Returns portal context for a student (legacy shape).
 
-	Same shape as get_student_info (student record + current_program +
-	student_groups) but for an explicit student, authorized for the student
-	themselves or a linked guardian.
+	Used where a single payload is expected. Prefer get_portal_student_profile
+	and get_portal_program_context for the portal SPA.
 
 	:param student: Student.
+	:param program: Optional Program to scope enrollment and student groups.
 	"""
-	check_permission(student, "profile")
-
-	student_info = frappe.db.get_value("Student", student, "*", as_dict=True)
-	if not student_info:
+	profile = get_portal_student_profile(student)
+	if not profile:
 		return None
 
-	current_program = get_current_enrollment(student_info.name)
-	if current_program:
-		student_groups = get_student_groups(student_info.name, current_program.program)
-		student_info["student_groups"] = student_groups
-		student_info["current_program"] = current_program
+	selected_program = program or profile.get("suggested_program")
+	student_info = profile["student"]
+	student_info["programs"] = profile["programs"]
+
+	if selected_program:
+		program_context = get_portal_program_context(student, selected_program)
+		student_info["current_program"] = program_context["enrollment"]
+		student_info["student_groups"] = program_context["student_groups"]
+
 	return student_info
 
 
@@ -659,9 +780,6 @@ def get_portal_context():
 	if role == "Guardian":
 		context["guardian"] = get_guardian_info()
 		context["students"] = get_guardian_students()
-	elif role == "Student":
-		context["student"] = get_student_info()
-
 	return context
 
 

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -852,6 +852,9 @@ def create_student_leave_application_based_on_course_schedule(leave_data, progra
 def create_student_leave_application_based_on_student_group(leave_data, program_name):
 	student_groups = get_student_groups(leave_data.get("student"), program_name)
 
+	if not student_groups:
+		frappe.throw(_("No student groups found for the student"))
+
 	student_leave_application = frappe.new_doc("Student Leave Application")
 	student_leave_application.student = leave_data.get("student")
 	student_leave_application.student_name = leave_data.get("student_name")

--- a/education/education/doctype/student_group/student_group.json
+++ b/education/education/doctype/student_group/student_group.json
@@ -133,7 +133,7 @@
   }
  ],
  "links": [],
- "modified": "2022-12-05 10:50:08.798494",
+ "modified": "2026-07-01 13:53:06.639243",
  "modified_by": "Administrator",
  "module": "Education",
  "name": "Student Group",
@@ -155,9 +155,18 @@
    "role": "Academics User",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Student",
+   "share": 1
   }
  ],
- "restrict_to_domain": "",
+ "row_format": "Dynamic",
  "search_fields": "program, batch, course",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/education/education/doctype/student_group/student_group.json
+++ b/education/education/doctype/student_group/student_group.json
@@ -133,7 +133,7 @@
   }
  ],
  "links": [],
- "modified": "2026-07-01 13:53:06.639243",
+ "modified": "2026-07-01 15:04:37.649308",
  "modified_by": "Administrator",
  "module": "Education",
  "name": "Student Group",
@@ -155,15 +155,6 @@
    "role": "Academics User",
    "share": 1,
    "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Student",
-   "share": 1
   }
  ],
  "row_format": "Dynamic",

--- a/education/hooks.py
+++ b/education/hooks.py
@@ -133,9 +133,7 @@ global_search_doctypes = {
 # home_page = "login"
 
 # website user home page (by Role)
-# role_home_page = {
-# 	"Role": "home_page"
-# }
+role_home_page = {"Student": "edu-portal", "Guardian": "edu-portal"}
 
 # Generators
 # ----------

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -2,12 +2,13 @@
   <header
     class="flex justify-between gap-3 items-center px-5 py-2.5 h-12 border-b"
   >
-    <div class="flex gap-2 items-center cursor-pointer">
-      <h3 class="font-medium text-lg text-gray-900">
+    <div class="flex gap-3 items-center cursor-pointer min-w-0">
+      <h3 class="font-medium text-lg text-gray-900 shrink-0">
         {{ currentRoute }}
       </h3>
+      <ProgramSelector v-if="showProgramSelector" />
     </div>
-    <div v-if="isStudent" class="flex flex-row gap-2">
+    <div v-if="isStudent" class="flex flex-row gap-2 shrink-0">
       <Button
         v-if="currentRoute === 'Attendance'"
         variant="solid"
@@ -21,12 +22,22 @@
 <script setup>
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { storeToRefs } from 'pinia'
 import { leaveStore } from '@/stores/leave'
 import { portalStore } from '@/stores/portal'
+import { studentStore } from '@/stores/student'
+import ProgramSelector from '@/components/ProgramSelector.vue'
 
 const router = useRouter()
 const currentRoute = computed(() => router.currentRoute.value.name)
 
 const { setIsAttendancePage } = leaveStore()
-const { isStudent } = portalStore()
+const { isStudent, isGuardian, activeStudentId } = storeToRefs(portalStore())
+const { programs } = storeToRefs(studentStore())
+
+const showProgramSelector = computed(() => {
+  if (currentRoute.value === 'Students') return false
+  if (isGuardian.value && !activeStudentId.value) return false
+  return programs.value.length > 0
+})
 </script>

--- a/frontend/src/components/ProgramSelector.vue
+++ b/frontend/src/components/ProgramSelector.vue
@@ -1,0 +1,34 @@
+<template>
+  <Dropdown v-if="programOptions.length > 1" :options="programOptions">
+    <template #default="{ open }">
+      <Button :label="activeProgram || 'Select Program'">
+        <template #suffix>
+          <FeatherIcon
+            :name="open ? 'chevron-up' : 'chevron-down'"
+            class="h-4 text-gray-600"
+          />
+        </template>
+      </Button>
+    </template>
+  </Dropdown>
+  <span v-else-if="activeProgram" class="text-sm font-medium text-gray-700">
+    {{ activeProgram }}
+  </span>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { Dropdown, FeatherIcon, Button } from 'frappe-ui'
+import { studentStore } from '@/stores/student'
+
+const store = studentStore()
+const { programs, activeProgram } = storeToRefs(store)
+
+const programOptions = computed(() =>
+  programs.value.map((row) => ({
+    label: row.program,
+    onClick: () => store.setActiveProgram(row.program),
+  }))
+)
+</script>

--- a/frontend/src/components/ProgramSelector.vue
+++ b/frontend/src/components/ProgramSelector.vue
@@ -11,7 +11,7 @@
       </Button>
     </template>
   </Dropdown>
-  <span v-else-if="activeProgram" class="text-sm font-medium text-gray-700">
+  <span v-else-if="activeProgram" class="text-m font-medium text-gray-700">
     {{ activeProgram }}
   </span>
 </template>

--- a/frontend/src/pages/Attendance.vue
+++ b/frontend/src/pages/Attendance.vue
@@ -94,6 +94,13 @@ const attendanceStatus = {
   Leave: 'bg-orange-100',
 }
 
+function resetNewLeave() {
+  newLeave.from_date = ''
+  newLeave.to_date = ''
+  newLeave.reason = ''
+  newLeave.total_days = ''
+}
+
 const attendanceResource = createResource({
   url: 'education.education.api.get_student_attendance',
   makeParams() {
@@ -136,6 +143,7 @@ const applyLeave = createResource({
       icon: 'check',
       iconClasses: 'text-green-600',
     })
+    resetNewLeave()
   },
   onError: (err) => {
     createToast({

--- a/frontend/src/pages/Attendance.vue
+++ b/frontend/src/pages/Attendance.vue
@@ -2,7 +2,7 @@
   <div class="py-4 flex flex-col">
     <div class="px-5 flex items-center gap-2">
       <h2 class="font-semibold text-2xl">{{ programName }}</h2>
-      <Dropdown :options="allStudentGroups">
+      <Dropdown v-if="allStudentGroups?.length" :options="allStudentGroups">
         <template #default="{ open }">
           <Button :label="selectedGroup">
             <template #suffix>
@@ -33,7 +33,7 @@
       <template #body-content>
         <NewLeave :newLeave="newLeave" />
       </template>
-      <template #actions="{ close }">
+      <template #actions>
         <div class="flex flex-row-reverse gap-2">
           <Button
             :disabled="
@@ -52,59 +52,41 @@
   </div>
 </template>
 <script setup>
-import { onMounted, reactive, ref } from 'vue'
+import { reactive, ref, watch } from 'vue'
 import { leaveStore } from '@/stores/leave'
 import { studentStore } from '@/stores/student'
-
 import { Dialog, createResource, Dropdown, FeatherIcon } from 'frappe-ui'
 import { storeToRefs } from 'pinia'
 import NewLeave from '@/components/NewLeave.vue'
 import Calendar from '@/components/Calendar.vue'
 import { createToast } from '@/utils'
 
-const { getCurrentProgram, getStudentInfo, getStudentGroups } = studentStore()
-const programName = ref(getCurrentProgram().value?.program)
-
-let studentInfo = getStudentInfo().value
-
-// storeToRefs converts isAttendancePage to a ref, hence achieving reactivity
+const { studentInfo, currentProgram, studentGroups } = storeToRefs(
+  studentStore()
+)
+const programName = ref('')
 const { isAttendancePage } = storeToRefs(leaveStore())
 
-onMounted(() => {
-  setStudentGroup()
-})
-
 const selectedGroup = ref('Select Student Group')
-const allStudentGroups = ref()
-function setStudentGroup() {
-  allStudentGroups.value = getStudentGroups().value
-  allStudentGroups.value.forEach(
-    (group) =>
-      (group.onClick = () => {
-        if (group.label === selectedGroup.value) return
-        selectedGroup.value = group.label
-        attendanceResource.reload()
-      })
-  )
-  selectedGroup.value =
-    allStudentGroups.value[0].label || 'Select Student Group'
-  attendanceResource.update({
-    params: {
-      student_group: selectedGroup.value,
-      student: studentInfo.name,
-    },
-  })
-  attendanceResource.reload()
-}
+const allStudentGroups = ref([])
 
 const newLeave = reactive({
-  student: studentInfo.name,
-  student_name: studentInfo.student_name,
+  student: '',
+  student_name: '',
   from_date: '',
   to_date: '',
   reason: '',
   total_days: '',
 })
+
+watch(
+  studentInfo,
+  (info) => {
+    newLeave.student = info?.name || ''
+    newLeave.student_name = info?.student_name || ''
+  },
+  { immediate: true, deep: true }
+)
 
 const attendanceStatus = {
   Present: 'bg-green-100',
@@ -114,40 +96,37 @@ const attendanceStatus = {
 
 const attendanceResource = createResource({
   url: 'education.education.api.get_student_attendance',
-  params: {
-    student_group: selectedGroup.value,
-    student: studentInfo.name,
+  makeParams() {
+    return {
+      student_group: selectedGroup.value,
+      student: studentInfo.value?.name,
+    }
   },
   transform: (attendance) => {
-    // filter attendance to remove duplicate attendance data
     attendance = attendance.filter(
-      (attendance, index, self) =>
-        index === self.findIndex((t) => t.date === attendance.date)
+      (row, index, self) => index === self.findIndex((t) => t.date === row.date)
     )
 
-    let events = []
-
-    attendance.forEach((attendance) => {
-      events.push({
-        name: attendance.name,
-        title: attendance.status,
-        background_color: attendanceStatus[attendance.status],
-        date: attendance.date,
-        status: attendance.status,
-      })
-    })
-    return events
+    return attendance.map((row) => ({
+      name: row.name,
+      title: row.status,
+      background_color: attendanceStatus[row.status],
+      date: row.date,
+      status: row.status,
+    }))
   },
   onError: (err) => {
-    console.log('Error', err)
+    console.warn('Error', err)
   },
 })
 
 const applyLeave = createResource({
   url: 'education.education.api.apply_leave',
-  params: {
-    leave_data: newLeave,
-    program_name: programName.value,
+  makeParams() {
+    return {
+      leave_data: newLeave,
+      program_name: currentProgram.value?.program,
+    }
   },
   onSuccess: () => {
     isAttendancePage.value = false
@@ -160,10 +139,42 @@ const applyLeave = createResource({
   },
   onError: (err) => {
     createToast({
-      title: err.messages[0] ?? 'Error Occured',
+      title: err.messages?.[0] ?? 'Error Occured',
       icon: 'x',
       iconClasses: 'text-red-600',
     })
   },
 })
+
+function setStudentGroup() {
+  const groups = (studentGroups.value || []).map((group) => ({
+    label: group.label,
+    onClick: () => {
+      if (group.label === selectedGroup.value) return
+      selectedGroup.value = group.label
+      attendanceResource.reload()
+    },
+  }))
+
+  allStudentGroups.value = groups
+  selectedGroup.value = groups[0]?.label || 'Select Student Group'
+
+  if (groups.length && studentInfo.value?.name) {
+    attendanceResource.reload()
+  }
+}
+
+watch(
+  [currentProgram, studentGroups, studentInfo],
+  () => {
+    programName.value = currentProgram.value?.program || ''
+    if (currentProgram.value?.program && studentGroups.value?.length) {
+      setStudentGroup()
+    } else {
+      allStudentGroups.value = []
+      selectedGroup.value = 'Select Student Group'
+    }
+  },
+  { deep: true, immediate: true }
+)
 </script>

--- a/frontend/src/pages/Fees.vue
+++ b/frontend/src/pages/Fees.vue
@@ -65,7 +65,7 @@
 </template>
 
 <script setup>
-import { reactive, ref } from 'vue'
+import { reactive, ref, watch } from 'vue'
 import {
   ListView,
   ListHeader,
@@ -77,16 +77,18 @@ import {
 } from 'frappe-ui'
 import FeesPaymentDialog from '@/components/FeesPaymentDialog.vue'
 import { studentStore } from '@/stores/student'
+import { storeToRefs } from 'pinia'
 import MissingData from '@/components/MissingData.vue'
 import { createToast } from '@/utils'
 
-const { getStudentInfo } = studentStore()
-let studentInfo = getStudentInfo().value
+const { studentInfo } = storeToRefs(studentStore())
 
 const feesResource = createResource({
   url: 'education.education.api.get_student_invoices',
-  params: {
-    student: studentInfo.name,
+  makeParams() {
+    return {
+      student: studentInfo.value?.name,
+    }
   },
   onSuccess: (response) => {
     printFormat = response?.print_format
@@ -103,8 +105,19 @@ const feesResource = createResource({
     })
     tableData.rows = invoices
   },
-  auto: true,
 })
+
+watch(
+  () => studentInfo.value?.name,
+  (student) => {
+    if (student) {
+      feesResource.reload()
+    } else {
+      tableData.rows = []
+    }
+  },
+  { immediate: true }
+)
 
 const tableData = reactive({
   rows: [],

--- a/frontend/src/pages/Grades.vue
+++ b/frontend/src/pages/Grades.vue
@@ -1,18 +1,6 @@
 <template lang="">
   <div v-if="grades.data?.length > 0">
     <div class="px-5 py-4">
-      <Dropdown class="mb-4" :options="allPrograms">
-        <template #default="{ open }">
-          <Button :label="selectedProgram">
-            <template #suffix>
-              <FeatherIcon
-                :name="open ? 'chevron-up' : 'chevron-down'"
-                class="h-4 text-gray-600"
-              />
-            </template>
-          </Button>
-        </template>
-      </Dropdown>
       <ListView
         class="h-[250px]"
         :columns="tableData.columns"
@@ -31,26 +19,14 @@
   </div>
 </template>
 <script setup>
-import {
-  Dropdown,
-  FeatherIcon,
-  ListView,
-  createResource,
-  createListResource,
-} from 'frappe-ui'
-import { ref } from 'vue'
+import { ListView, createListResource } from 'frappe-ui'
+import { ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import { studentStore } from '@/stores/student'
 import { groupBy } from '@/utils'
-
 import MissingData from '@/components/MissingData.vue'
 
-const { getCurrentProgram, getStudentInfo } = studentStore()
-
-let studentInfo = getStudentInfo().value
-let currentProgram = getCurrentProgram().value
-
-const allPrograms = ref([])
-const selectedProgram = ref('')
+const { studentInfo, currentProgram } = storeToRefs(studentStore())
 
 const tableData = ref({
   columns: [
@@ -66,28 +42,6 @@ const tableData = ref({
   rows: [],
 })
 
-const student_programs = createResource({
-  url: 'education.education.api.get_student_programs',
-  makeParams() {
-    return {
-      // student: studentInfo.value?.name
-      student: studentInfo.name,
-    }
-  },
-  onSuccess: (response) => {
-    let programs = []
-    response.forEach((program) => {
-      programs.push({
-        label: program.program,
-        onClick: () => (selectedProgram.value = program.program),
-      })
-    })
-    selectedProgram.value = programs[programs.length - 1].label
-    allPrograms.value = programs
-  },
-  auto: true,
-})
-
 const grades = createListResource({
   doctype: 'Assessment Result',
   fields: [
@@ -100,24 +54,26 @@ const grades = createListResource({
     'grade',
   ],
   filters: {
-    student: studentInfo.name,
-    program: currentProgram.program,
-    // student:"EDU-STU-2023-00005",
-    // program:"Comp Science"
+    student: studentInfo.value?.name,
+    program: currentProgram.value?.program,
   },
-  transform: () => {},
-
   onSuccess: (response) => {
-    let conductedExams = groupBy(response, (row) => row.assessment_group)
-    let exams = Object.keys(conductedExams)
+    tableData.value.columns = [
+      { label: 'Course', key: 'course' },
+      { label: 'Batch', key: 'batch' },
+    ]
+    tableData.value.rows = []
+
+    const conductedExams = groupBy(response, (row) => row.assessment_group)
+    const exams = Object.keys(conductedExams)
     updateColumns(exams)
-    let courses = groupBy(response, (row) => row.course)
+    const courses = groupBy(response, (row) => row.course)
     Object.keys(courses).forEach((course) => {
-      let row = {}
+      const row = {}
       row.course = course
       row.batch = courses[course][0].student_group
       exams.forEach((exam) => {
-        let examData = conductedExams[exam].find((row) => row.course === course)
+        const examData = conductedExams[exam].find((r) => r.course === course)
         row[exam] = examData
           ? `${examData.total_score}/${examData.maximum_score}`
           : '-'
@@ -125,15 +81,32 @@ const grades = createListResource({
       tableData.value.rows.push(row)
     })
   },
-  auto: true,
 })
+
+watch(
+  () => [studentInfo.value?.name, currentProgram.value?.program],
+  ([student, program]) => {
+    if (!student || !program) {
+      tableData.value.rows = []
+      return
+    }
+    grades.update({
+      filters: {
+        student,
+        program,
+      },
+    })
+    grades.reload()
+  },
+  { immediate: true }
+)
 
 const updateColumns = (exams) => {
   exams.forEach((exam) => {
-    let col = {}
-    col.label = exam
-    col.key = exam
-    tableData.value.columns.push(col)
+    tableData.value.columns.push({
+      label: exam,
+      key: exam,
+    })
   })
 }
 </script>

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -1,31 +1,31 @@
 <template>
   <div class="w-full h-full">
-    <Calendar
-      v-if="!scheduleResource.loading && scheduleResource.data"
-      :events="events"
-    />
+    <Calendar v-if="events.length" :events="events" />
+    <MissingData v-else message="No schedule found" />
   </div>
 </template>
 
 <script setup>
 import Calendar from '@/components/Calendar.vue'
+import MissingData from '@/components/MissingData.vue'
 import { createResource } from 'frappe-ui'
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import { studentStore } from '@/stores/student'
-const { getCurrentProgram, getStudentGroups } = studentStore()
 
-const programName = ref(getCurrentProgram()?.value?.program)
-const studentGroup = ref(getStudentGroups().value)
+const { currentProgram, studentGroups } = storeToRefs(studentStore())
 const events = ref([])
 
 const scheduleResource = createResource({
   url: 'education.education.api.get_course_schedule_for_student',
-  params: {
-    program_name: programName.value,
-    student_groups: studentGroup.value,
+  makeParams() {
+    return {
+      program_name: currentProgram.value?.program,
+      student_groups: studentGroups.value,
+    }
   },
   onSuccess: (response) => {
-    let schedule = []
+    const schedule = []
     response.forEach((classSchedule) => {
       schedule.push({
         title: classSchedule.title,
@@ -40,8 +40,19 @@ const scheduleResource = createResource({
     })
     events.value = schedule
   },
-  auto: true,
 })
+
+watch(
+  [currentProgram, studentGroups],
+  () => {
+    if (currentProgram.value?.program && studentGroups.value?.length) {
+      scheduleResource.reload()
+    } else {
+      events.value = []
+    }
+  },
+  { deep: true, immediate: true }
+)
 </script>
 
 <style></style>

--- a/frontend/src/pages/Students.vue
+++ b/frontend/src/pages/Students.vue
@@ -34,7 +34,7 @@
           </p>
           <div>
             <p class="truncate text-sm text-gray-500">
-              relation: {{ s.relation }}
+              relation: {{ s.relation || 'Not Specified' }}
             </p>
           </div>
         </div>

--- a/frontend/src/stores/student.js
+++ b/frontend/src/stores/student.js
@@ -3,64 +3,159 @@ import { ref } from 'vue'
 import { createResource } from 'frappe-ui'
 import { portalStore } from '@/stores/portal'
 
+function storedProgramKey(studentId) {
+  return `education-active-program-${studentId}`
+}
+
+function readStoredProgram(studentId) {
+  if (!studentId) return null
+  return localStorage.getItem(storedProgramKey(studentId))
+}
+
+function writeStoredProgram(studentId, program) {
+  if (!studentId) return
+  if (program) {
+    localStorage.setItem(storedProgramKey(studentId), program)
+  } else {
+    localStorage.removeItem(storedProgramKey(studentId))
+  }
+}
+
 export const studentStore = defineStore('education-student', () => {
   const studentInfo = ref({})
+  const programs = ref([])
+  const activeProgram = ref(null)
   const currentProgram = ref({})
   const studentGroups = ref([])
 
   const portal = portalStore()
 
-  function setInfo(info) {
-    if (!info) {
-      studentInfo.value = {}
+  function studentParams() {
+    if (portal.isGuardian && portal.activeStudentId) {
+      return { student: portal.activeStudentId }
+    }
+    return {}
+  }
+
+  function resolveStudentId() {
+    if (portal.isGuardian) {
+      return portal.activeStudentId
+    }
+    return studentInfo.value?.name
+  }
+
+  function reset() {
+    studentInfo.value = {}
+    programs.value = []
+    activeProgram.value = null
+    currentProgram.value = {}
+    studentGroups.value = []
+  }
+
+  function applyProgramContext(data) {
+    if (!data) {
       currentProgram.value = {}
       studentGroups.value = []
       return
     }
-    currentProgram.value = info.current_program || {}
-    studentGroups.value = info.student_groups || []
-    const rest = { ...info }
-    delete rest.current_program
-    delete rest.student_groups
-    studentInfo.value = rest
+    currentProgram.value = data.enrollment || {}
+    studentGroups.value = data.student_groups || []
   }
 
-  // Logged-in student viewing their own record.
-  const selfStudent = createResource({
-    url: 'education.education.api.get_student_info',
-    onSuccess: setInfo,
+  function applyProfile(data) {
+    if (!data) {
+      reset()
+      return null
+    }
+
+    studentInfo.value = data.student || {}
+    programs.value = data.programs || []
+
+    const studentId = data.student?.name
+    const programNames = programs.value.map((p) => p.program)
+    let program = readStoredProgram(studentId)
+
+    if (program && !programNames.includes(program)) {
+      program = null
+      writeStoredProgram(studentId, null)
+    }
+    if (!program) {
+      program = data.suggested_program
+    }
+    if (!program && programs.value.length) {
+      program = programs.value[0].program
+    }
+
+    activeProgram.value = program
+    if (program) {
+      writeStoredProgram(studentId, program)
+    }
+    return program
+  }
+
+  const studentProfile = createResource({
+    url: 'education.education.api.get_portal_student_profile',
+    makeParams: studentParams,
     onError: (err) => console.warn(err),
   })
 
-  // Guardian viewing the currently selected student
-  const guardianStudent = createResource({
-    url: 'education.education.api.get_student_context',
+  const programContext = createResource({
+    url: 'education.education.api.get_portal_program_context',
     makeParams() {
-      return { student: portal.activeStudentId }
+      return {
+        ...studentParams(),
+        program: activeProgram.value,
+      }
     },
-    onSuccess: setInfo,
     onError: (err) => console.warn(err),
   })
+
+  async function loadProgramContext() {
+    if (!activeProgram.value) {
+      applyProgramContext(null)
+      return
+    }
+    await programContext.reload()
+    applyProgramContext(programContext.data)
+  }
 
   async function loadStudent() {
-    if (portal.isGuardian) {
-      if (!portal.activeStudentId) {
-        setInfo(null)
-        return
-      }
-      return guardianStudent.reload()
+    if (portal.isGuardian && !portal.activeStudentId) {
+      reset()
+      return
     }
-    if (portal.isStudent) {
-      return selfStudent.reload()
+
+    await studentProfile.reload()
+    const program = applyProfile(studentProfile.data)
+    if (program) {
+      await loadProgramContext()
+    } else {
+      applyProgramContext(null)
     }
   }
 
-  // Backwards-compatible interface: the router and session store call
-  // student.reload() to (re)load the active student's context.
+  async function setActiveProgram(program) {
+    const studentId = resolveStudentId()
+    if (!program || !studentId) return
+
+    const programNames = programs.value.map((p) => p.program)
+    if (!programNames.includes(program)) return
+
+    activeProgram.value = program
+    writeStoredProgram(studentId, program)
+    await loadProgramContext()
+  }
+
   const student = { reload: loadStudent, fetch: loadStudent }
 
   function getStudentInfo() {
     return studentInfo
+  }
+  function getPrograms() {
+    return programs
+  }
+  function getActiveProgram() {
+    return activeProgram
   }
   function getCurrentProgram() {
     return currentProgram
@@ -72,10 +167,16 @@ export const studentStore = defineStore('education-student', () => {
   return {
     student,
     studentInfo,
+    programs,
+    activeProgram,
     currentProgram,
     studentGroups,
     loadStudent,
+    loadProgramContext,
+    setActiveProgram,
     getStudentInfo,
+    getPrograms,
+    getActiveProgram,
     getCurrentProgram,
     getStudentGroups,
   }

--- a/frontend/src/stores/student.js
+++ b/frontend/src/stores/student.js
@@ -94,13 +94,13 @@ export const studentStore = defineStore('education-student', () => {
   }
 
   const studentProfile = createResource({
-    url: 'education.education.api.get_portal_student_profile',
+    url: 'education.education.api.get_student_profile',
     makeParams: studentParams,
     onError: (err) => console.warn(err),
   })
 
   const programContext = createResource({
-    url: 'education.education.api.get_portal_program_context',
+    url: 'education.education.api.get_program_context',
     makeParams() {
       return {
         ...studentParams(),


### PR DESCRIPTION
## Summary

Extends the education student portal so users with multiple program enrollments can choose an active program and see schedule, grades, and attendance, scoped to that program. 

### Program selection and scoped portal data 
- Add `get_student_profile` and `get_program_context` backend APIs to load student profile, all submitted enrollments, and student groups for the selected program
- Refactor `studentStore` to load profile then program context sequentially; persist the selected program per student in `localStorage`
- Add `ProgramSelector` in the navbar for multi-program users
- Make Schedule, Grades, and Attendance reactive to program/student changes

### Portal API cleanup and routing
- Rename portal endpoints to `get_student_profile` / `get_program_context` and update the SPA store accordingly
- Set `role_home_page` for Student and Guardian roles to `edu-portal`

### Leave application refactor
- Replace direct `make_attendance_records` calls with submitted `Student Leave Application` documents
- Reset leave form fields after successful submission in Attendance.vue