### PR TITLE
fix: remove invalid doc.guardian reference breaking guardian search functionality

### DIFF
--- a/education/education/doctype/student/student.js
+++ b/education/education/doctype/student/student.js
@@ -35,7 +35,6 @@ frappe.ui.form.on('Student Guardian', {
     frm.fields_dict['guardians'].grid.get_field('guardian').get_query =
       function (doc) {
         let guardian_list = []
-        if (!doc.__islocal) guardian_list.push(doc.guardian)
         $.each(doc.guardians, function (idx, val) {
           if (val.guardian) guardian_list.push(val.guardian)
         })


### PR DESCRIPTION
Fixes #428

## Problem
When linking a Guardian to a Student via the Relations tab, the Guardian 
search field showed "Filtered by: Name is not one of ." and no results 
could be found, even for newly created Guardians.

## Root Cause
In `student.js`, the `guardians_add` handler builds a `get_query` filter 
to exclude already-linked guardians. It included this line:

if (!doc.__islocal) guardian_list.push(doc.guardian)

`doc.guardian` (singular) does not exist as a field on the Student doctype 
- only the `guardians` child table exists. This pushed `undefined` into 
`guardian_list`, producing a malformed filter that broke the search entirely.

## Fix
Removed the invalid line referencing the non-existent `doc.guardian` field. 
The existing logic that correctly builds the exclusion list from 
`doc.guardians` (to prevent linking the same guardian twice) is untouched.

## Testing
- Created a Guardian, linked it to a new Student's Relations tab - search 
  now works correctly
- Added a second Guardian row - confirmed the already-linked guardian is 
  still correctly excluded from search results (duplicate-prevention logic 
  still works)