### PR TITLE
feat: grant Guardian desk access and Sales Invoice permissions

### DIFF
--- a/education/install.py
+++ b/education/install.py
@@ -7,6 +7,7 @@ from frappe.permissions import add_permission, update_permission_property
 def after_install():
 	setup_fixtures()
 	create_student_role()
+	create_guardian_role()
 	create_parent_assessment_group()
 	create_invoice_permissions()
 	create_custom_fields(get_custom_fields())
@@ -42,12 +43,12 @@ def create_parent_assessment_group():
 
 def create_student_role():
 	if not frappe.db.exists("Role", "Student"):
-		frappe.get_doc({"doctype": "Role", "role_name": "Student", "desk_access": 0}).save()
+		frappe.get_doc({"doctype": "Role", "role_name": "Student", "desk_access": 1}).save()
 
 
 def create_guardian_role():
 	if not frappe.db.exists("Role", "Guardian"):
-		frappe.get_doc({"doctype": "Role", "role_name": "Guardian", "desk_access": 0}).save()
+		frappe.get_doc({"doctype": "Role", "role_name": "Guardian", "desk_access": 1}).save()
 
 
 def create_invoice_permissions():

--- a/education/patches.txt
+++ b/education/patches.txt
@@ -17,3 +17,4 @@ education.patches.v15_0.create_fee_component_item_group
 education.patches.v15_0.create_student_customer_group
 education.patches.v15_0.create_custom_permissions
 education.patches.v15_0.create_guardian_role
+education.patches.v15_0.guardian_invoice_permission

--- a/education/patches/v15_0/create_guardian_role.py
+++ b/education/patches/v15_0/create_guardian_role.py
@@ -3,4 +3,4 @@ import frappe
 
 def execute():
 	if not frappe.db.exists("Role", "Guardian"):
-		frappe.get_doc({"doctype": "Role", "role_name": "Guardian", "desk_access": 0}).save()
+		frappe.get_doc({"doctype": "Role", "role_name": "Guardian", "desk_access": 1}).save()

--- a/education/patches/v15_0/guardian_invoice_permission.py
+++ b/education/patches/v15_0/guardian_invoice_permission.py
@@ -1,0 +1,18 @@
+import frappe
+
+from education.install import create_permissions
+
+
+def execute():
+	if not frappe.db.exists("Role", "Guardian"):
+		return
+
+	permissions = [
+		{
+			"doctype": "Sales Invoice",
+			"role": "Guardian",
+			"permlevel": 0,
+			"ptype": ["read", "print"],
+		},
+	]
+	create_permissions(permissions)


### PR DESCRIPTION
Enable the Guardian role for desk use and wire invoice access into install and migrate paths so guardians can view student fees.

- Create Guardian role during after_install alongside Student setup
- Set desk_access=1 for Student and Guardian roles (install + patch)
- Add patch granting Guardian read/print on Sales Invoice
- Register guardian_invoice_permission in patches.txt