### PR TITLE
fix: prevent null guardian filter in student

### DIFF
--- a/education/education/doctype/student/student.js
+++ b/education/education/doctype/student/student.js
@@ -35,7 +35,6 @@ frappe.ui.form.on('Student Guardian', {
     frm.fields_dict['guardians'].grid.get_field('guardian').get_query =
       function (doc) {
         let guardian_list = []
-        if (!doc.__islocal) guardian_list.push(doc.guardian)
         $.each(doc.guardians, function (idx, val) {
           if (val.guardian) guardian_list.push(val.guardian)
         })


### PR DESCRIPTION
Fixes #483 

One line fix. Removing the line leaves guardian_list as a clean array (empty or populated correctly by sibling rows), so the not in filter no longer contains [null] and the query returns results as expected.

The expectation is that if a guardian is already added in the array, that record must be excluded from the filters.

https://github.com/user-attachments/assets/57e328df-3567-4760-8ec8-451f931cec93

