### PR TITLE
fix: make student customer creation optional

### DIFF
--- a/education/education/doctype/education_settings/education_settings.json
+++ b/education/education/doctype/education_settings/education_settings.json
@@ -14,6 +14,7 @@
   "academic_term_reqd",
   "user_creation_skip",
   "accounting_section",
+  "customer_creation_skip",
   "create_so",
   "column_break_aimg",
   "auto_submit_sales_invoice",
@@ -149,6 +150,13 @@
    "label": "Accounting"
   },
   {
+   "default": "0",
+   "description": "By default, a Customer is created and linked to every new Student to support fee, invoicing and receivable workflows. If enabled, no Customer will be created automatically when a Student is saved. A Customer is still created on-demand when a Fee Schedule is generated for the Student.",
+   "fieldname": "customer_creation_skip",
+   "fieldtype": "Check",
+   "label": "Skip Customer creation for new Student"
+  },
+  {
    "fieldname": "column_break_aimg",
    "fieldtype": "Column Break"
   },
@@ -178,7 +186,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2026-02-04 12:15:05.069346",
+ "modified": "2026-09-08 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Education",
  "name": "Education Settings",

--- a/education/education/doctype/fee_schedule/fee_schedule.py
+++ b/education/education/doctype/fee_schedule/fee_schedule.py
@@ -263,7 +263,9 @@ def create_sales_order(fee_schedule, student_id):
 def get_customer_from_student(student_id):
 	student = frappe.get_doc("Student", student_id)
 	if not student.customer:
-		student.set_missing_customer_details()
+		# A Customer is required for the accounting flow, so create it on-demand
+		# even if automatic Customer creation is skipped in Education Settings.
+		student.set_missing_customer_details(force=True)
 	return frappe.db.get_value("Student", student.name, "customer")
 
 

--- a/education/education/doctype/student/student.py
+++ b/education/education/doctype/student/student.py
@@ -28,11 +28,21 @@ class Student(Document):
 		# This prevents from polluting users data
 		self.set_missing_customer_details()
 
-	def set_missing_customer_details(self):
-		self.set_customer_group()
+	def set_missing_customer_details(self, force=False):
+		"""Keep the linked Customer in sync, creating one if needed.
+
+		Automatic Customer creation can be disabled via the "Skip Customer creation
+		for new Student" toggle in Education Settings for non-fee-based implementations.
+		Pass ``force=True`` (e.g. from the Fee Schedule flow) to create the Customer
+		on-demand even when the toggle is enabled, since accounting features require it.
+		"""
 		if self.customer:
+			self.set_customer_group()
 			self.update_linked_customer()
-		else:
+		elif force or not frappe.db.get_single_value(
+			"Education Settings", "customer_creation_skip"
+		):
+			self.set_customer_group()
 			self.create_customer()
 
 	def set_customer_group(self):

--- a/education/education/doctype/student/test_student.py
+++ b/education/education/doctype/student/test_student.py
@@ -25,5 +25,14 @@ class TestStudent(FrappeTestCase):
 		self.assertTrue(bool(student.customer))
 		self.assertEqual(student.customer_group, "Student")
 
+	def test_skip_customer_creation_for_student(self):
+		frappe.db.set_single_value("Education Settings", "customer_creation_skip", 1)
+		try:
+			student = create_student(student_email_id="skip-customer@example.com")
+			student.reload()
+			self.assertFalse(bool(student.customer))
+		finally:
+			frappe.db.set_single_value("Education Settings", "customer_creation_skip", 0)
+
 	def tearDown(self):
 		frappe.db.rollback()


### PR DESCRIPTION
## Problem

Currently, a Customer is automatically created whenever a Student is created.

This creates unnecessary accounting entities for institutions that:

- Do not use fee management
- Do not use ERPNext accounting
- Only use Education for academic management

## Solution

- Added an Education Settings option to enable/disable automatic customer creation.
- Customer creation remains enabled by default to preserve existing behavior.
- When disabled, students are created without creating corresponding Customer records.

## Related Issue

Closes #432

## Testing

- Verified student creation with setting enabled.
- Verified student creation with setting disabled.
- Existing fee workflows continue to work when enabled.

<img width="1830" height="923" alt="Screenshot from 2026-09-08 19-08-12" src="https://github.com/user-attachments/assets/f9a62799-24db-41c3-bfc4-0996339d1f09" />
